### PR TITLE
Fix styling

### DIFF
--- a/.github/workflows/cpp-check.yml
+++ b/.github/workflows/cpp-check.yml
@@ -1,6 +1,6 @@
 name: test-clang-format
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   cpp_style_check:

--- a/.github/workflows/python-check.yml
+++ b/.github/workflows/python-check.yml
@@ -1,5 +1,5 @@
 name: python style check
-on: [push]
+on: [push, pull_request]
 jobs:
   check-python-style:
     runs-on: ubuntu-latest

--- a/mirte_telemetrix/scripts/mappings/pico.py
+++ b/mirte_telemetrix/scripts/mappings/pico.py
@@ -8,9 +8,7 @@ def pin_name_to_pin_number(pin):  # pico has no mapping
     if pin.isdigit():
         return int(pin)
 
-    raise RuntimeError(
-        f"Unknown conversion from pin {pin} to an IO number."
-    )
+    raise RuntimeError(f"Unknown conversion from pin {pin} to an IO number.")
 
 
 def get_analog_offset():


### PR DESCRIPTION
GitHub did not block the pull request because the styling check was not on the mirte-robot/mirte-ros-packages repo yet and the workflows did not trigger on pull-request