### PR TITLE
Keypad fix

### DIFF
--- a/mirte_telemetrix/config/mirte_user_config.yaml
+++ b/mirte_telemetrix/config/mirte_user_config.yaml
@@ -16,17 +16,17 @@ distance:
     pins:
       trigger: GP9
       echo: GP8
-encoder:
-  left:
-    name: left
-    device: mirte
-    pins:
-      pin: GP15
-  right:
-    name: right
-    device: mirte
-    pins:
-      pin: GP14
+#encoder:
+#  left:
+#    name: left
+#    device: mirte
+#    pins:
+#      pin: GP15
+#  right:
+#    name: right
+#    device: mirte
+#    pins:
+#      pin: GP14
 intensity:
   left:
     name: left 
@@ -40,13 +40,13 @@ intensity:
     pins:
       analog: GP27
       digital: GP17
-oled:
-  left:
-    name: left
-    device: mirte
-    pins:
-      sda: GP4
-      scl: GP5
+#oled:
+#  left:
+#    name: left
+#    device: mirte
+#    pins:
+#      sda: GP4
+#      scl: GP5
 #  right:
 #    name: right
 #    device: mirte

--- a/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
+++ b/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
@@ -30,7 +30,7 @@ async def analog_write(board, pin, value):
     if board_mapping.get_mcu() == "pico":
         await board.pwm_write(pin, value)
     else:
-        await board.analog_write(board, pin, value)
+        await board.analog_write(pin, value)
 
 
 # Import ROS message types

--- a/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
+++ b/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
@@ -192,7 +192,7 @@ class KeypadMonitor(SensorMonitor):
     async def publish_data(self, data):
         # Determine the key that is pressed
         # TODO: these values were found on a 12 bits adc, and
-        # added a scaling for the actual bits used. We could 
+        # added a scaling for the actual bits used. We could
         # calculate this with the R values used.
         key = ""
         if data[2] < 70 / 4096 * (2 ** board_mapping.get_adc_bits()):

--- a/mirte_telemetrix/scripts/mappings/default.py
+++ b/mirte_telemetrix/scripts/mappings/default.py
@@ -25,5 +25,9 @@ def get_analog_offset():
     return 0
 
 
+def get_adc_bits():
+    return 12
+
+
 def get_max_pwm_value():
     return 255

--- a/mirte_telemetrix/scripts/mappings/nanoatmega328.py
+++ b/mirte_telemetrix/scripts/mappings/nanoatmega328.py
@@ -30,6 +30,10 @@ def get_analog_offset():
     return 14
 
 
+def get_adc_bits():
+    return 12
+
+
 def get_max_pwm_value():
     return 255
 

--- a/mirte_telemetrix/scripts/mappings/pcb.py
+++ b/mirte_telemetrix/scripts/mappings/pcb.py
@@ -42,6 +42,10 @@ def get_analog_offset():
     return board_mapping.get_analog_offset()
 
 
+def get_adc_bits():
+    return board_mapping.get_adc_bits()
+
+
 def connector_to_pins(connector):
     if connector in connector_mapping:
         return connector_mapping[connector]

--- a/mirte_telemetrix/scripts/mappings/pico.py
+++ b/mirte_telemetrix/scripts/mappings/pico.py
@@ -15,6 +15,12 @@ def get_analog_offset():
     return 26
 
 
+def get_adc_bits():
+    # NOTE: the pico itself has 12 bits, but micropython will upgrade to 16
+    # no clue why 14 works
+    return 14
+
+
 def get_max_pwm_value():
     return 100
 

--- a/mirte_telemetrix/scripts/mappings/stm32.py
+++ b/mirte_telemetrix/scripts/mappings/stm32.py
@@ -43,6 +43,10 @@ def get_analog_offset():
     return 20
 
 
+def get_adc_bits():
+    return 12
+
+
 def pin_name_to_pin_number(pin):
     if pin in stm32_map:
         return stm32_map[pin]


### PR DESCRIPTION
This PR:
- fixes #11 
- little cleanup
- fix for analog write for non-pico boards
- disables encoder (not used in v0.1) and oled (not working yet)