### PR TITLE
Fix Telemetrix not restarting

### DIFF
--- a/mirte_bringup/launch/minimal.launch
+++ b/mirte_bringup/launch/minimal.launch
@@ -11,7 +11,9 @@
          mcu -->
     <node name="mirte_telemetrix_mirte" output="screen"
           pkg="mirte_telemetrix"
-          type="ROS_telemetrix_aio_api.py"/>
+          type="ROS_telemetrix_aio_api.py"
+          respawn="true"
+          respawn_delay="5"/>
 
     <!-- ROS control hardware interface for differential
          drive robot. -->

--- a/mirte_bringup/launch/minimal.launch
+++ b/mirte_bringup/launch/minimal.launch
@@ -12,8 +12,7 @@
     <node name="mirte_telemetrix_mirte" output="screen"
           pkg="mirte_telemetrix"
           type="ROS_telemetrix_aio_api.py"
-          respawn="true"
-          respawn_delay="5"/>
+          respawn="true"/>
 
     <!-- ROS control hardware interface for differential
          drive robot. -->

--- a/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
+++ b/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
@@ -1029,6 +1029,7 @@ async def shutdown(loop, board):
         # Stop the asyncio loop
         loop.stop()
         print("Telemetrix shutdown nicely")
+        rospy.signal_shutdown(0)
 
 
 if __name__ == "__main__":

--- a/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
+++ b/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
@@ -1030,6 +1030,8 @@ async def shutdown(loop, board):
         loop.stop()
         print("Telemetrix shutdown nicely")
         rospy.signal_shutdown(0)
+        time.sleep(1)
+        exit(0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixed by:
- The launch file will restart the telemetrix node if it stopped with some delay for the microcontroller to possibly also restart.
- Stopping the rospy node at shutdown for a clean shutdown