### PR TITLE
Fix #29 servo sg90 not using full 180deg range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 __pycache__
+
+.vscode/

--- a/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
+++ b/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
@@ -391,7 +391,7 @@ class Servo:
             self.max_pulse = servo_obj["max_pulse"]
         else:
             self.max_pulse = 2400
-        
+
     async def stop(self):
         await board.detach_servo(self.pins["pin"])
 

--- a/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
+++ b/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
@@ -383,14 +383,12 @@ class Servo:
         self.board = board
         self.pins = get_pin_numbers(servo_obj)
         self.name = servo_obj["name"]
+        self.min_pulse = 544
         if "min_pulse" in servo_obj:
             self.min_pulse = servo_obj["min_pulse"]
-        else:
-            self.min_pulse = 544
+        self.max_pulse = 2400
         if "max_pulse" in servo_obj:
             self.max_pulse = servo_obj["max_pulse"]
-        else:
-            self.max_pulse = 2400
 
     async def stop(self):
         await board.detach_servo(self.pins["pin"])

--- a/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
+++ b/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
@@ -390,7 +390,7 @@ class Servo:
         if "max_pulse" in servo_obj:
             self.max_pulse = servo_obj["max_pulse"]
         else:
-            self.max_pulse = 544
+            self.max_pulse = 2400
         
     async def stop(self):
         await board.detach_servo(self.pins["pin"])

--- a/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
+++ b/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
@@ -383,12 +383,20 @@ class Servo:
         self.board = board
         self.pins = get_pin_numbers(servo_obj)
         self.name = servo_obj["name"]
-
+        if "min_pulse" in servo_obj:
+            self.min_pulse = servo_obj["min_pulse"]
+        else:
+            self.min_pulse = 544
+        if "max_pulse" in servo_obj:
+            self.max_pulse = servo_obj["max_pulse"]
+        else:
+            self.max_pulse = 544
+        
     async def stop(self):
         await board.detach_servo(self.pins["pin"])
 
     async def start(self):
-        await board.set_pin_mode_servo(self.pins["pin"])
+        await board.set_pin_mode_servo(self.pins["pin"], self.min_pulse, self.max_pulse)
         server = rospy.Service(
             "/mirte/set_" + self.name + "_servo_angle",
             SetServoAngle,


### PR DESCRIPTION
Always send min_pulse and max_pulse to telemetrix api.

The arduino python code sends it to the arduino, the pico api will store it and use it to compute the duty cycle that it sends to the rp2040.

Add `min_pulse: 544` and/or `max_pulse: 2400` to the user config to change the min and max pulse length for 0-180° of the servo.