### PR TITLE
Fix 34 control node does not reconnect to telemetrix node after tmx restart

### DIFF
--- a/mirte_control/CMakeLists.txt
+++ b/mirte_control/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0.2)
 project(mirte_control)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
+add_compile_options(-std=c++14)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/mirte_control/include/my_robot_hw_interface.h
+++ b/mirte_control/include/my_robot_hw_interface.h
@@ -31,9 +31,8 @@
 
 #include <chrono>
 #include <future>
-#include <thread>
 #include <mutex>
-
+#include <thread>
 
 const unsigned int NUM_JOINTS = 2;
 
@@ -47,8 +46,8 @@ public:
    */
   void write() {
     if (running_) {
-      // make sure the clients don't get overwritten while calling them 
-      const std::lock_guard<std::mutex> lock(this->service_clients_mutex); 
+      // make sure the clients don't get overwritten while calling them
+      const std::lock_guard<std::mutex> lock(this->service_clients_mutex);
 
       // cmd[0] = ros_control calculated speed of left motor in rad/s
       // cmd[1] = ros_control calculated speed of right motor in rad/s
@@ -193,10 +192,10 @@ void MyRobotHWInterface::init_service_clients() {
   ros::service::waitForService("/mirte/set_right_speed");
   {
     const std::lock_guard<std::mutex> lock(this->service_clients_mutex);
-  this->left_client = nh.serviceClient<mirte_msgs::SetMotorSpeed>(
-      "/mirte/set_left_speed", true);
-  this->right_client = nh.serviceClient<mirte_msgs::SetMotorSpeed>(
-      "/mirte/set_right_speed", true);
+    this->left_client = nh.serviceClient<mirte_msgs::SetMotorSpeed>(
+        "/mirte/set_left_speed", true);
+    this->right_client = nh.serviceClient<mirte_msgs::SetMotorSpeed>(
+        "/mirte/set_right_speed", true);
   }
 }
 
@@ -254,14 +253,16 @@ void MyRobotHWInterface::start_reconnect() {
 
     // Use wait_for() with zero milliseconds to check thread status.
     auto status = this->reconnect_thread.wait_for(0ms);
-    
-    if (status != std::future_status::ready) { // Still running -> already reconnecting
+
+    if (status !=
+        std::future_status::ready) { // Still running -> already reconnecting
       return;
     }
   }
 
-  /* Run the reconnection on a different thread to not pause the ros-control loop. 
-    The launch policy std::launch::async makes sure that the task is run asynchronously on a new thread. */
+  /* Run the reconnection on a different thread to not pause the ros-control
+    loop. The launch policy std::launch::async makes sure that the task is run
+    asynchronously on a new thread. */
 
   this->reconnect_thread =
       std::async(std::launch::async, [this] { this->init_service_clients(); });

--- a/mirte_control/include/my_robot_hw_interface.h
+++ b/mirte_control/include/my_robot_hw_interface.h
@@ -1,5 +1,5 @@
 // https://slaterobots.com/blog/5abd8a1ed4442a651de5cb5b/how-to-implement-ros_control-on-a-custom-robot
-// Roughlt based on:
+// Roughly based on:
 // https://github.com/eborghi10/my_ROS_mobile_robot/blob/master/my_robot_base/include/my_robot_hw_interface.h
 // https://github.com/PickNikRobotics/ros_control_boilerplate
 // https://github.com/DeborggraeveR/ampru
@@ -32,6 +32,8 @@
 #include <chrono>
 #include <future>
 #include <thread>
+#include <mutex>
+
 
 const unsigned int NUM_JOINTS = 2;
 
@@ -45,37 +47,41 @@ public:
    */
   void write() {
     if (running_) {
+      // make sure the clients don't get overwritten while calling them 
+      const std::lock_guard<std::mutex> lock(this->service_clients_mutex); 
+
       // cmd[0] = ros_control calculated speed of left motor in rad/s
       // cmd[1] = ros_control calculated speed of right motor in rad/s
 
       // This function converts cmd[0] to pwm and calls that service
 
-      // NOTE: this *highly* depends on teh voltage of the motors!!!!
-      // For 5V power bank: 255 pwm = 90 ticks/sec -> ca 2 omwenteling/s (4*pi)
-      // For 6V power supply: 255 pwm = 120 ticks/sec -> ca 3 omwentelingen/s
+      // NOTE: this *highly* depends on the voltage of the motors!!!!
+      // For 5V power bank: 255 pwm = 90 ticks/sec -> ca 2 rot/s (4*pi)
+      // For 6V power supply: 255 pwm = 120 ticks/sec -> ca 3 rot/s
       // (6*pi)
 
       int left_speed =
           std::max(std::min(int(cmd[0] / (6 * M_PI) * 100), 100), -100);
       if (left_speed != _last_cmd[0]) {
         left_motor_service.request.speed = left_speed;
+        _last_cmd[0] = left_speed;
         if (!left_client.call(left_motor_service)) {
           this->start_reconnect();
+          return;
         }
-        _last_cmd[0] = left_speed;
       }
 
       int right_speed =
           std::max(std::min(int(cmd[1] / (6 * M_PI) * 100), 100), -100);
       if (right_speed != _last_cmd[1]) {
         right_motor_service.request.speed = right_speed;
+        _last_cmd[1] = right_speed;
         if (!right_client.call(right_motor_service)) {
           this->start_reconnect();
         }
-        _last_cmd[1] = right_speed;
       }
       // Set the direction in so the read() can use it
-      // TODO: this does not work propely, because at the end of a series
+      // TODO: this does not work properly, because at the end of a series
       // cmd_vel is negative, while the rotation is not
       _last_wheel_cmd_direction[0] = cmd[0] > 0.0 ? 1 : -1;
       _last_wheel_cmd_direction[1] = cmd[1] > 0.0 ? 1 : -1;
@@ -83,7 +89,7 @@ public:
   }
 
   /**
-   * Reading encoder values and setting position and velocity of enconders
+   * Reading encoder values and setting position and velocity of encoders
    */
   void read(const ros::Duration &period) {
     //_wheel_encoder[0] = number of ticks of left encoder since last call of
@@ -179,16 +185,19 @@ private:
   std::future<void> reconnect_thread;
   void init_service_clients();
   void start_reconnect();
+  std::mutex service_clients_mutex;
 }; // class
 
 void MyRobotHWInterface::init_service_clients() {
   ros::service::waitForService("/mirte/set_left_speed");
   ros::service::waitForService("/mirte/set_right_speed");
-  // TODO: mutex
+  {
+    const std::lock_guard<std::mutex> lock(this->service_clients_mutex);
   this->left_client = nh.serviceClient<mirte_msgs::SetMotorSpeed>(
       "/mirte/set_left_speed", true);
   this->right_client = nh.serviceClient<mirte_msgs::SetMotorSpeed>(
       "/mirte/set_right_speed", true);
+  }
 }
 
 MyRobotHWInterface::MyRobotHWInterface()
@@ -200,7 +209,7 @@ MyRobotHWInterface::MyRobotHWInterface()
   private_nh.param<double>("wheel_diameter", _wheel_diameter, 0.06);
   private_nh.param<double>("max_speed", _max_speed, 2.0);
 
-  // Intialize raw data
+  // Initialize raw data
   std::fill_n(pos, NUM_JOINTS, 0.0);
   std::fill_n(vel, NUM_JOINTS, 0.0);
   std::fill_n(eff, NUM_JOINTS, 0.0);
@@ -236,8 +245,6 @@ MyRobotHWInterface::MyRobotHWInterface()
                    &MyRobotHWInterface::rightWheelEncoderCallback, this);
 
   this->init_service_clients();
-  // TODO: checl ion isvalis when running
-  // https://answers.ros.org/question/281411/persistent-service-initialization/
 }
 
 void MyRobotHWInterface::start_reconnect() {
@@ -247,13 +254,14 @@ void MyRobotHWInterface::start_reconnect() {
 
     // Use wait_for() with zero milliseconds to check thread status.
     auto status = this->reconnect_thread.wait_for(0ms);
-    // Print status.
-    if (status != std::future_status::ready) { // Still running
+    
+    if (status != std::future_status::ready) { // Still running -> already reconnecting
       return;
     }
   }
-  /* Run some task on new thread. The launch policy std::launch::async
-     makes sure that the task is run asynchronously on a new thread. */
+
+  /* Run the reconnection on a different thread to not pause the ros-control loop. 
+    The launch policy std::launch::async makes sure that the task is run asynchronously on a new thread. */
 
   this->reconnect_thread =
       std::async(std::launch::async, [this] { this->init_service_clients(); });


### PR DESCRIPTION
Closes #34 by reconnecting to the service server when a disconnection is detected.

As the ros-control loop should not be delayed, a new thread is spawned (only once) when a disconnect is detected. This thread will try to reconnect. During this reconnecting, the ros-control loop will keep running and no other threads are started.