### PR TITLE
36 add catkin lint

### DIFF
--- a/.github/workflows/catkin-lint.yml
+++ b/.github/workflows/catkin-lint.yml
@@ -33,11 +33,11 @@ jobs:
       - run: |
           . catkin_ws/devel/setup.sh
           failure=0
-          catkin_lint --pkg mirte_bringup || failure=1
-          catkin_lint --pkg mirte_control || failure=1
-          catkin_lint --pkg mirte_msgs || failure=1
-          catkin_lint --pkg mirte_telemetrix || failure=1
-          catkin_lint --pkg mirte_teleop || failure=1
+          catkin_lint --explain --ignore uninstalled_target --pkg mirte_bringup || failure=1
+          catkin_lint --explain --ignore uninstalled_target --pkg mirte_control || failure=1
+          catkin_lint --explain --ignore uninstalled_target --pkg mirte_msgs || failure=1
+          catkin_lint --explain --ignore uninstalled_target --pkg mirte_telemetrix || failure=1
+          catkin_lint --explain --ignore uninstalled_target --pkg mirte_teleop || failure=1
           if failure; then
               echo "Automated tests failed" >&2
           exit 1

--- a/.github/workflows/catkin-lint.yml
+++ b/.github/workflows/catkin-lint.yml
@@ -27,11 +27,11 @@ jobs:
       - run: |
           . catkin_ws/devel/setup.sh
           failure=false
-          catkin_lint --explain --ignore uninstalled_target --pkg mirte_bringup || failure=true
-          catkin_lint --explain --ignore uninstalled_target --pkg mirte_control || failure=true
-          catkin_lint --explain --ignore uninstalled_target --pkg mirte_msgs || failure=true
-          catkin_lint --explain --ignore uninstalled_target --pkg mirte_telemetrix || failure=true
-          catkin_lint --explain --ignore uninstalled_target --pkg mirte_teleop || failure=true
+          catkin_lint --explain --ignore uninstalled_target --ignore uninstalled_script --pkg mirte_bringup || failure=true
+          catkin_lint --explain --ignore uninstalled_target --ignore uninstalled_script --pkg mirte_control || failure=true
+          catkin_lint --explain --ignore uninstalled_target --ignore uninstalled_script --pkg mirte_msgs || failure=true
+          catkin_lint --explain --ignore uninstalled_target --ignore uninstalled_script --pkg mirte_telemetrix || failure=true
+          catkin_lint --explain --ignore uninstalled_target --ignore uninstalled_script --pkg mirte_teleop || failure=true
           if $failure; then
               echo "Automated tests failed" >&2
           exit 1

--- a/.github/workflows/catkin-lint.yml
+++ b/.github/workflows/catkin-lint.yml
@@ -1,0 +1,48 @@
+name: Catkin_lint ros style check
+on: [push, pull_request]
+jobs:
+  check_ros_style:
+    runs-on: ubuntu-latest
+    container:
+      image: ros:noetic
+    steps:
+      - uses: actions/checkout@v3
+      - run: echo "catkin_lint" > ./requirements.txt
+      # - uses: actions/setup-python@v4
+      #   with:
+      #     python-version: '3.9'
+      #     cache: 'pip' # caching pip dependencies
+      # - run: apt install python-pip
+      - run: apt update && apt install catkin-lint -y
+      - run: |
+          mkdir -p catkin_ws/src
+          mv mirte_bringup catkin_ws/src/
+          mv mirte_control catkin_ws/src/
+          mv mirte_msgs catkin_ws/src/
+          mv mirte_telemetrix catkin_ws/src/
+          mv mirte_teleop catkin_ws/src/
+          cd catkin_ws/src
+          . /opt/ros/noetic/setup.sh
+          catkin_init_workspace
+          cd ..
+          rosdep init || true
+          rosdep update || true
+          rosdep install -y --from-paths src/ --ignore-src --rosdistro noetic
+          catkin_make
+          . devel/setup.sh
+      - run: |
+          . catkin_ws/devel/setup.sh
+          failure=0
+          catkin_lint --pkg mirte_bringup || failure=1
+          catkin_lint --pkg mirte_control || failure=1
+          catkin_lint --pkg mirte_msgs || failure=1
+          catkin_lint --pkg mirte_telemetrix || failure=1
+          catkin_lint --pkg mirte_teleop || failure=1
+          if failure; then
+              echo "Automated tests failed" >&2
+          exit 1
+          else
+              echo "Automated tests succeeded" >&2
+              exit 0
+          fi
+

--- a/.github/workflows/catkin-lint.yml
+++ b/.github/workflows/catkin-lint.yml
@@ -7,12 +7,6 @@ jobs:
       image: ros:noetic
     steps:
       - uses: actions/checkout@v3
-      - run: echo "catkin_lint" > ./requirements.txt
-      # - uses: actions/setup-python@v4
-      #   with:
-      #     python-version: '3.9'
-      #     cache: 'pip' # caching pip dependencies
-      # - run: apt install python-pip
       - run: apt update && apt install catkin-lint -y
       - run: |
           mkdir -p catkin_ws/src
@@ -32,13 +26,13 @@ jobs:
           . devel/setup.sh
       - run: |
           . catkin_ws/devel/setup.sh
-          failure=0
-          catkin_lint --explain --ignore uninstalled_target --pkg mirte_bringup || failure=1
-          catkin_lint --explain --ignore uninstalled_target --pkg mirte_control || failure=1
-          catkin_lint --explain --ignore uninstalled_target --pkg mirte_msgs || failure=1
-          catkin_lint --explain --ignore uninstalled_target --pkg mirte_telemetrix || failure=1
-          catkin_lint --explain --ignore uninstalled_target --pkg mirte_teleop || failure=1
-          if failure; then
+          failure=false
+          catkin_lint --explain --ignore uninstalled_target --pkg mirte_bringup || failure=true
+          catkin_lint --explain --ignore uninstalled_target --pkg mirte_control || failure=true
+          catkin_lint --explain --ignore uninstalled_target --pkg mirte_msgs || failure=true
+          catkin_lint --explain --ignore uninstalled_target --pkg mirte_telemetrix || failure=true
+          catkin_lint --explain --ignore uninstalled_target --pkg mirte_teleop || failure=true
+          if $failure; then
               echo "Automated tests failed" >&2
           exit 1
           else

--- a/.github/workflows/catkin-lint.yml
+++ b/.github/workflows/catkin-lint.yml
@@ -1,4 +1,4 @@
-name: Catkin_lint ros style check
+name: Compile and catkin_lint ros style check
 on: [push, pull_request]
 jobs:
   check_ros_style:
@@ -6,7 +6,7 @@ jobs:
     container:
       image: ros:noetic
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: apt update && apt install catkin-lint -y
       - run: |
           mkdir -p catkin_ws/src
@@ -27,11 +27,12 @@ jobs:
       - run: |
           . catkin_ws/devel/setup.sh
           failure=false
-          catkin_lint --explain --ignore uninstalled_target --ignore uninstalled_script --pkg mirte_bringup || failure=true
-          catkin_lint --explain --ignore uninstalled_target --ignore uninstalled_script --pkg mirte_control || failure=true
-          catkin_lint --explain --ignore uninstalled_target --ignore uninstalled_script --pkg mirte_msgs || failure=true
-          catkin_lint --explain --ignore uninstalled_target --ignore uninstalled_script --pkg mirte_telemetrix || failure=true
-          catkin_lint --explain --ignore uninstalled_target --ignore uninstalled_script --pkg mirte_teleop || failure=true
+          # Run all tests before failing to test all packages
+          catkin_lint --strict --explain --ignore uninstalled_target --ignore uninstalled_script --pkg mirte_bringup || failure=true
+          catkin_lint --strict --explain --ignore uninstalled_target --ignore uninstalled_script --pkg mirte_control || failure=true
+          catkin_lint --strict --explain --ignore uninstalled_target --ignore uninstalled_script --pkg mirte_msgs || failure=true
+          catkin_lint --strict --explain --ignore uninstalled_target --ignore uninstalled_script --pkg mirte_telemetrix || failure=true
+          catkin_lint --strict --explain --ignore uninstalled_target --ignore uninstalled_script --pkg mirte_teleop || failure=true
           if $failure; then
               echo "Automated tests failed" >&2
           exit 1

--- a/mirte_bringup/CMakeLists.txt
+++ b/mirte_bringup/CMakeLists.txt
@@ -103,6 +103,9 @@ find_package(catkin REQUIRED COMPONENTS
 #  CATKIN_DEPENDS roscpp rospy std_msgs mirte_msgs message_runtime controller_manager hardware_interface
 #  DEPENDS system_lib
 #)
+catkin_package(
+ CATKIN_DEPENDS
+)
 
 
 ###########

--- a/mirte_bringup/package.xml
+++ b/mirte_bringup/package.xml
@@ -15,6 +15,7 @@
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
   <license>Apache2</license>
 
+  <exec_depend>controller_manager</exec_depend>
 
   <!-- Url tags are optional, but multiple are allowed, one per tag -->
   <!-- Optional attribute type can be: website, bugtracker, or repository -->

--- a/mirte_control/CMakeLists.txt
+++ b/mirte_control/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
   mirte_msgs
   controller_manager
   hardware_interface
+  trajectory_msgs
 )
 
 ## System dependencies are found with CMake's conventions
@@ -103,9 +104,9 @@ find_package(catkin REQUIRED COMPONENTS
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-  INCLUDE_DIRS include
+  # INCLUDE_DIRS include/
 #  LIBRARIES mirte_ros_package
-  CATKIN_DEPENDS roscpp std_msgs mirte_msgs message_runtime controller_manager hardware_interface
+  CATKIN_DEPENDS roscpp std_msgs mirte_msgs message_runtime controller_manager hardware_interface trajectory_msgs
 #  DEPENDS system_lib
 )
 

--- a/mirte_control/package.xml
+++ b/mirte_control/package.xml
@@ -50,24 +50,27 @@
   <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>roscpp</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>mirte_msgs</build_depend>
-  <build_depend>controller_manager</build_depend>
-  <build_depend>hardware_interface</build_depend>
-  <build_depend>trajectory_msgs</build_depend>
-  <build_export_depend>roscpp</build_export_depend>
-  <build_export_depend>std_msgs</build_export_depend>
+  <depend>roscpp</depend>
+  <depend>std_msgs</depend>
+  <depend>mirte_msgs</depend>
+  <depend>controller_manager</depend>
+  <depend>hardware_interface</depend>
+  <depend>trajectory_msgs</depend>
+  <exec_depend>diff_drive_controller</exec_depend>
+  <exec_depend>effort_controllers</exec_depend>
+  <exec_depend>message_runtime</exec_depend>
 
-  <exec_depend>roscpp</exec_depend>
+    <!-- <depend>roscpp</build_export_depend> -->
+  <!-- <build_export_depend>std_msgs</build_export_depend> -->
+
+  <!-- <exec_depend>roscpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>mirte_msgs</exec_depend>
-  <exec_depend>message_runtime</exec_depend>
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>hardware_interface</exec_depend>
-  <exec_depend>effort_controllers</exec_depend>
-  <exec_depend>trajectory_msgs</exec_depend>
-  <exec_depend>diff_drive_controller</exec_depend>
+  
+  <build_export_depend >trajectory_msgs</build_export_depend >
+   -->
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/mirte_msgs/CMakeLists.txt
+++ b/mirte_msgs/CMakeLists.txt
@@ -49,14 +49,14 @@ find_package(catkin REQUIRED COMPONENTS
 ##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
 
 ## Generate messages in the 'msg' folder
- add_message_files(
+add_message_files(
    FILES
    Encoder.msg
    color.msg
    Intensity.msg
    IntensityDigital.msg
    Keypad.msg
- )
+)
 
 ## Generate services in the 'srv' folder
 add_service_files(

--- a/mirte_telemetrix/CMakeLists.txt
+++ b/mirte_telemetrix/CMakeLists.txt
@@ -11,7 +11,6 @@ find_package(catkin REQUIRED COMPONENTS
   rospy
   std_msgs
   mirte_msgs
-  roslaunch
 )
 
 ## System dependencies are found with CMake's conventions

--- a/mirte_telemetrix/package.xml
+++ b/mirte_telemetrix/package.xml
@@ -55,6 +55,7 @@
   <build_depend>mirte_msgs</build_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
+  <build_export_depend>mirte_msgs</build_export_depend>
 
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>

--- a/mirte_teleop/CMakeLists.txt
+++ b/mirte_teleop/CMakeLists.txt
@@ -9,6 +9,9 @@ add_compile_options(-std=c++11)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
 )
+catkin_package(
+ CATKIN_DEPENDS
+)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)


### PR DESCRIPTION
Add catkin_lint to improve our code quality and show students how to build 'good' ROS nodes.

The workflow also compiles the mirte_* packages, so it will also detect errors in any C++ code.