### PR TITLE
Add pcb version 0.8

### DIFF
--- a/mirte_telemetrix/config/mirte_pcb06_config.yaml
+++ b/mirte_telemetrix/config/mirte_pcb06_config.yaml
@@ -44,6 +44,7 @@ oled:
 #    name: left
 #    device: mirte
 #    connector: Servo1
+servo:  
   right:
     name: right
     device: mirte

--- a/mirte_telemetrix/config/mirte_pcb06_config.yaml
+++ b/mirte_telemetrix/config/mirte_pcb06_config.yaml
@@ -39,7 +39,7 @@ oled:
     name: right
     device: mirte
     connector: I2C1
-# Servo on GP2 doens't work with the v0.6 pcb, next version this should be fixed
+# Servo on GP2 doesn't work with the v0.6 pcb, next version this should be fixed
 #  left:
 #    name: left
 #    device: mirte

--- a/mirte_telemetrix/config/mirte_pcb06_config.yaml
+++ b/mirte_telemetrix/config/mirte_pcb06_config.yaml
@@ -59,7 +59,6 @@ servo:
     name: arm
     device: mirte
     connector: Servo4
-
 keypad:
   yellow:
     name: keypad

--- a/mirte_telemetrix/config/mirte_pcb08_config.yaml
+++ b/mirte_telemetrix/config/mirte_pcb08_config.yaml
@@ -58,7 +58,6 @@ servo:
     name: arm
     device: mirte
     connector: Servo4
-
 keypad:
   yellow:
     name: keypad

--- a/mirte_telemetrix/config/mirte_pcb08_config.yaml
+++ b/mirte_telemetrix/config/mirte_pcb08_config.yaml
@@ -1,115 +1,90 @@
 device:
   mirte:
-    type: breadboard
-    board: pico
-#    max_frequency: 50
+    type: pcb
+    version: 0.8
+    max_frequency: 50
 distance:
   left:
     name: left
     device: mirte
-    pins:
-      trigger: GP9
-      echo: GP8
+    connector: SRF1
   right:
     name: right
     device: mirte
-    pins:
-      trigger: GP7
-      echo: GP6
-#encoder:
-#  left:
-#    name: left
-#    device: mirte
-#    pins:
-#      pin: GP14
-#  right:
-#    name: right
-#    device: mirte
-#    pins:
-#      pin: GP15
+    connector: SRF2
+encoder:
+  left:
+    name: left
+    device: mirte
+    connector: ENC1
+  right:
+    name: right
+    device: mirte
+    connector: ENC2
 intensity:
   left:
     name: left
     device: mirte
-    pins:
-      analog: GP27
-      digital: GP17
+    connector: IR1
   right:
     name: right
     device: mirte
-    pins:
-      analog: GP26
-      digital: GP16
+    connector: IR2
 oled:
   left:
     name: left
     device: mirte
-    pins:
-      sda: GP10
-      scl: GP11
+    connector: I2C2
   right:
     name: right
     device: mirte
-    pins:
-      sda: GP4
-      scl: GP5
+    connector: I2C1
 servo:
   left:
     name: left
     device: mirte
-    pins:
-      pin: GP14
+    connector: Servo1
   right:
     name: right
     device: mirte
-    pins:
-      pin: GP15
+    connector: Servo2
   # These servo's have the same pins as the ObjectDetectors. So as
   # soon as they are implemented, these should be commented out
   gripper:
     name: gripper
     device: mirte
-    pins:
-      pin: GP12
+    connector: Servo3
   arm:
     name: arm
     device: mirte
-    pins:
-      pin: GP13
+    connector: Servo4
+
 keypad:
   yellow:
-    name: yellow
+    name: keypad
     device: mirte
-    pins:
-      pin: GP28
+    connector: Keypad
 motor:
   left:
     name: left
     device: mirte
+    connector: MC1-A
     type: pp
-    pins:
-      p1: GP18
-      p2: GP19
   right:
     name: right
     device: mirte
+    connector: MC1-B
     type: pp
-    pins:
-      p1: GP20
-      p2: GP21
 # These motors have the same pins as the line intensity sensors. So
 # when uncommenting these, please comment the intensity sensors.
 #  left2:
 #    name: left2
 #    device: mirte
+#    connector: MC2-A
 #    type: pp
-#    pins:
-#      p1: GP26
-#      p2: GP16
 #  right2:
 #    name: right2
 #    device: mirte
+#    connector: MC2-B
 #    type: pp
-#    pins:
-#      p1: GP27
-#      p2: GP17
+# TODO: add obstacle detection

--- a/mirte_telemetrix/config/old/mirte_pcb04stm_config.yaml
+++ b/mirte_telemetrix/config/old/mirte_pcb04stm_config.yaml
@@ -47,8 +47,7 @@ servo:
     name: left
     device: mirte
     connector: Servo1
-servo:
-  left:
+  right:
     name: right
     device: mirte
     connector: Servo2

--- a/mirte_telemetrix/scripts/mappings/pcb.py
+++ b/mirte_telemetrix/scripts/mappings/pcb.py
@@ -3,7 +3,7 @@ import mappings.nanoatmega328
 import mappings.blackpill_f103c8
 
 
-mirte_pico_pcb_map06 = {
+mirte_pico_pcb_map08 = {
     "IR1": {"digital": "16", "analog": "26"},
     "IR2": {"digital": "17", "analog": "27"},
     "SRF1": {"trigger": "7", "echo": "6"},
@@ -13,25 +13,21 @@ mirte_pico_pcb_map06 = {
     "ENC1": {"pin": "15"},
     "ENC2": {"pin": "14"},
     "Keypad": {"pin": "28"},
-    "Servo1": {
-        "pin": "2"
-    },  # These 2 servos don't work together with the motor controllers at the same time
-    "Servo2": {
-        "pin": "3"
-    },  # These 2 servos don't work together with the motor controllers at the same time
+    "Servo1": {"pin": "14"},
+    "Servo2": {"pin": "15"},
     "Servo3": {"pin": "12"},
     "Servo4": {"pin": "13"},
-    "LED": {"pin": "25"},
-    "MC1-A": {"1a": "19", "1b": "18"},
-    "MC1-B": {"1a": "21", "1b": "20"},
-    "MC2-A": {"1a": "16", "1b": "26"},
-    "MC2-B": {"1a": "17", "1b": "27"},
+    "LED": {"pin": "25"},  # Does not work with the Pico W
+    "MC1-A": generate_motor_mapping("19", "18"),
+    "MC1-B": generate_motor_mapping("21", "20"),
+    "MC2-A": generate_motor_mapping("16", "26"),
+    "MC2-B": generate_motor_mapping("17", "27"),
 }
 
 
-version = 0.6
+version = 0.8
 board_mapping = mappings.pico
-connector_mapping = mirte_pico_pcb_map06
+connector_mapping = mirte_pico_pcb_map08
 
 
 def get_mcu():
@@ -65,8 +61,12 @@ def get_I2C_port(sda):
 def set_version(new_version, mcu=""):
     global version, board_mapping, connector_mapping
     version = new_version
+    if version == 0.8:
+        board_mapping = mappings.pico
+        connector_mapping = mirte_pico_pcb_map08
     if version == 0.6:
         board_mapping = mappings.pico
+        connector_mapping = mirte_pico_pcb_map06
     if version == 0.4:
         if mcu == "" or mcu == "stm32":
             board_mapping = mappings.stm32
@@ -86,7 +86,44 @@ def get_max_pwm_value():
     return board_mapping.get_max_pwm_value()
 
 
+def generate_motor_mapping(pin_a, pin_b):
+    # pin a has preference for pwm
+    # This will make sure, dp, pp and dd is always possible when using a connector without knowing what type of control
+    #     	A	B
+    # pp	P1	P2
+    # dp	P1	D1
+    # dd	D2	D1 # Not available
+    # ddp   TODO connectors
+    # Downside: when changing from pp/dp to dd, the direction will change
+
+    return {"p1": pin_a, "p2": pin_b, "d1": pin_b, "d2": pin_a}
+
+
 # mappings for older pcbs
+mirte_pico_pcb_map06 = {
+    "IR1": {"digital": "16", "analog": "26"},
+    "IR2": {"digital": "17", "analog": "27"},
+    "SRF1": {"trigger": "7", "echo": "6"},
+    "SRF2": {"trigger": "9", "echo": "8"},
+    "I2C1": {"scl": "5", "sda": "4"},
+    "I2C2": {"scl": "11", "sda": "10"},
+    "ENC1": {"pin": "15"},
+    "ENC2": {"pin": "14"},
+    "Keypad": {"pin": "28"},
+    "Servo1": {
+        "pin": "2"
+    },  # These 2 servos don't work together with the motor controllers at the same time
+    "Servo2": {
+        "pin": "3"
+    },  # These 2 servos don't work together with the motor controllers at the same time
+    "Servo3": {"pin": "12"},
+    "Servo4": {"pin": "13"},
+    "LED": {"pin": "25"},
+    "MC1-A": generate_motor_mapping("19", "18"),
+    "MC1-B": generate_motor_mapping("21", "20"),
+    "MC2-A": generate_motor_mapping("16", "26"),
+    "MC2-B": generate_motor_mapping("17", "27"),
+}
 
 mirte_pcb04_stm_map = {
     "IR1": {"digital": "C15", "analog": "A0"},
@@ -103,10 +140,10 @@ mirte_pcb04_stm_map = {
     "Servo1": {"pin": "B3"},
     "Servo2": {"pin": "A3"},
     "LED": {"pin": "C13"},
-    "MA": {"d1": "A8", "p1": "B5"},
-    "MB": {"d1": "B14", "p1": "B15"},
-    "MC": {"d1": "A10", "p1": "A7"},
-    "MD": {"d1": "B13", "p1": "A9"},
+    "MC1-A": generate_motor_mapping("B5", "A8"),
+    "MC1-B": generate_motor_mapping("B15", "B14"),
+    "MC2-A": generate_motor_mapping("A7", "A10"),
+    "MC2-B": generate_motor_mapping("A9", "B13"),
 }
 
 mirte_pcb04_nano_map = {
@@ -120,8 +157,8 @@ mirte_pcb04_nano_map = {
     "Servo1": {"pin": "A3"},
     "Servo2": {"pin": "D12"},
     "LED": {"pin": "D13"},
-    "MA": {"d1": "D6", "p1": "D7"},
-    "MB": {"d1": "D4", "p1": "D5"},
+    "MC1-A": generate_motor_mapping("D7", "D6"),
+    "MC1-B": generate_motor_mapping("D5", "D4"),
 }
 
 mirte_pcb03_stm_map = {
@@ -139,10 +176,10 @@ mirte_pcb03_stm_map = {
     "A2": {"pin": "A2"},
     "A3": {"pin": "A3"},
     "LED": {"pin": "C13"},
-    "MC1A": {"d1": "A8", "p1": "B3"},
-    "MC1B": {"d1": "B14", "p1": "B15"},
-    "MC2A": {"d1": "A10", "p1": "B1"},
-    "MC2B": {"1d": "B13", "p1": "A9"},
+    "MC1A": generate_motor_mapping("B3", "A8"),
+    "MC1B": generate_motor_mapping("B15", "B14"),
+    "MC2A": generate_motor_mapping("B1", "A10"),
+    "MC2B": generate_motor_mapping("A9", "B13"),
 }
 
 
@@ -160,6 +197,6 @@ mirte_pcb02_stm_map = {
     "A2": {"pin": "A2"},
     "A3": {"pin": "A3"},
     "LED": {"pin": "C13"},
-    "MA": {"d1": "A8", "p1": "B3"},
-    "MB": {"d1": "B14", "p1": "B15"},
+    "MA": generate_motor_mapping("B3", "A8"),
+    "MB": generate_motor_mapping("B15", "B14"),
 }

--- a/mirte_telemetrix/scripts/mappings/pcb.py
+++ b/mirte_telemetrix/scripts/mappings/pcb.py
@@ -3,33 +3,6 @@ import mappings.nanoatmega328
 import mappings.blackpill_f103c8
 
 
-mirte_pico_pcb_map08 = {
-    "IR1": {"digital": "16", "analog": "26"},
-    "IR2": {"digital": "17", "analog": "27"},
-    "SRF1": {"trigger": "7", "echo": "6"},
-    "SRF2": {"trigger": "9", "echo": "8"},
-    "I2C1": {"scl": "5", "sda": "4"},
-    "I2C2": {"scl": "11", "sda": "10"},
-    "ENC1": {"pin": "15"},
-    "ENC2": {"pin": "14"},
-    "Keypad": {"pin": "28"},
-    "Servo1": {"pin": "14"},
-    "Servo2": {"pin": "15"},
-    "Servo3": {"pin": "12"},
-    "Servo4": {"pin": "13"},
-    "LED": {"pin": "25"},  # Does not work with the Pico W
-    "MC1-A": generate_motor_mapping("19", "18"),
-    "MC1-B": generate_motor_mapping("21", "20"),
-    "MC2-A": generate_motor_mapping("16", "26"),
-    "MC2-B": generate_motor_mapping("17", "27"),
-}
-
-
-version = 0.8
-board_mapping = mappings.pico
-connector_mapping = mirte_pico_pcb_map08
-
-
 def get_mcu():
     return board_mapping.get_mcu()
 
@@ -98,6 +71,32 @@ def generate_motor_mapping(pin_a, pin_b):
 
     return {"p1": pin_a, "p2": pin_b, "d1": pin_b, "d2": pin_a}
 
+
+mirte_pico_pcb_map08 = {
+    "IR1": {"digital": "16", "analog": "26"},
+    "IR2": {"digital": "17", "analog": "27"},
+    "SRF1": {"trigger": "7", "echo": "6"},
+    "SRF2": {"trigger": "9", "echo": "8"},
+    "I2C1": {"scl": "5", "sda": "4"},
+    "I2C2": {"scl": "11", "sda": "10"},
+    "ENC1": {"pin": "15"},
+    "ENC2": {"pin": "14"},
+    "Keypad": {"pin": "28"},
+    "Servo1": {"pin": "14"},
+    "Servo2": {"pin": "15"},
+    "Servo3": {"pin": "12"},
+    "Servo4": {"pin": "13"},
+    "LED": {"pin": "25"},  # Does not work with the Pico W
+    "MC1-A": generate_motor_mapping("19", "18"),
+    "MC1-B": generate_motor_mapping("21", "20"),
+    "MC2-A": generate_motor_mapping("16", "26"),
+    "MC2-B": generate_motor_mapping("17", "27"),
+}
+
+
+version = 0.8
+board_mapping = mappings.pico
+connector_mapping = mirte_pico_pcb_map08
 
 # mappings for older pcbs
 mirte_pico_pcb_map06 = {

--- a/mirte_telemetrix/scripts/mappings/pcb.py
+++ b/mirte_telemetrix/scripts/mappings/pcb.py
@@ -61,13 +61,13 @@ def get_max_pwm_value():
 
 def generate_motor_mapping(pin_a, pin_b):
     # pin a has preference for pwm
+    # Different controllers(single pwm with direction, 2 pwm channels, 2 digital channels, 2 digital + 1 pwm) use different pin names.
     # This will make sure, dp, pp and dd is always possible when using a connector without knowing what type of control
     #     	A	B
     # pp	P1	P2
     # dp	P1	D1
-    # dd	D2	D1 # Not available
-    # ddp   TODO connectors
-    # Downside: when changing from pp/dp to dd, the direction will change
+    # dd	D2	D1 # Not (yet) available the ROS_telemetrix code. Downside when adding this: when changing from pp/dp to dd, the direction will change. Only fix is to let this system know the type of controller.
+    # ddp   TODO connectors, as there is no third pin on a motor connector.
 
     return {"p1": pin_a, "p2": pin_b, "d1": pin_b, "d2": pin_a}
 


### PR DESCRIPTION
- Adds a function to easily define motor connectors for using with dp and pp
- Adds pcb v0.8 mapping, sets it as default
- Adds pcb v0,8 config file
- Servos and motors (both all 4) tested
- Changes motor control to pp
- Sets user config to pcb v0.8 config using the pins, not connectors