### PR TITLE
Fix oled by using thread safe run_coroutine_threadsafe

### DIFF
--- a/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
+++ b/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
@@ -672,8 +672,10 @@ class Oled(_SSD1306):
         try:
             # the ros service is started on a different thread than the asyncio loop
             # When using the normal loop.run_until_complete() function, both threads join in and the oled communication will get broken faster
-            future = asyncio.run_coroutine_threadsafe(self.set_oled_image_service_async(req), self.loop) 
-            future.result() # wait for it to be done
+            future = asyncio.run_coroutine_threadsafe(
+                self.set_oled_image_service_async(req), self.loop
+            )
+            future.result()  # wait for it to be done
         except Exception as e:
             print(e)
         return SetOLEDImageResponse(True)


### PR DESCRIPTION
the ros service is started on a different thread than the asyncio loop. 
When using the normal loop.run_until_complete() function, both threads join in and there might be race conditions and the oled function might break faster.
With run_corotine_threadsafe, the function is started on the asyncio thread, without the ros service thread joining in and 'helping'. 

Tested it with this code:
```
from mirte_robot import robot
mirte=robot.createRobot()
for count2 in range(100000000):
  mirte.setOLEDText('left', ('Hi' + str(count2)))
```
Worked for at least 10 minutes at 5Hz.