### PR TITLE
Fix arduino tmx

### DIFF
--- a/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
+++ b/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
@@ -628,7 +628,7 @@ class Oled(_SSD1306):
             # // TODO: arduino will just stop forwarding i2c write messages after a single failed message. No feedback from it yet.
             out = await self.board.i2c_write(60, cmd, i2c_port=self.i2c_port)
             if out is None:
-                await asyncio.sleep(0.1)
+                await asyncio.sleep(0.01)
             if (
                 out == False
             ):  # pico returns true/false, arduino returns always none, only catch false
@@ -759,7 +759,7 @@ class Oled(_SSD1306):
             buf[0] = 0x40
             out = await self.board.i2c_write(60, buf, i2c_port=self.i2c_port)
             if out is None:
-                await asyncio.sleep(0.1)
+                await asyncio.sleep(0.01)
             if out == False:
                 print("failed wrcmd")
                 self.failed = True

--- a/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
+++ b/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
@@ -627,7 +627,7 @@ class Oled(_SSD1306):
         for cmd in self.write_commands:
             # // TODO: arduino will just stop forwarding i2c write messages after a single failed message. No feedback from it yet.
             out = await self.board.i2c_write(60, cmd, i2c_port=self.i2c_port)
-            if(out is None):
+            if out is None:
                 await asyncio.sleep(0.1)
             if (
                 out == False
@@ -719,7 +719,7 @@ class Oled(_SSD1306):
         self.temp[0] = 0x80
         self.temp[1] = cmd
         out = await self.board.i2c_write(60, self.temp, i2c_port=self.i2c_port)
-        if(out is None):
+        if out is None:
             await asyncio.sleep(0.01)
         if out == False:
             print("failed write oled 2")
@@ -758,11 +758,12 @@ class Oled(_SSD1306):
             buf = self.buffer[i * 16 : (i + 1) * 16 + 1]
             buf[0] = 0x40
             out = await self.board.i2c_write(60, buf, i2c_port=self.i2c_port)
-            if(out is None):
+            if out is None:
                 await asyncio.sleep(0.1)
             if out == False:
                 print("failed wrcmd")
                 self.failed = True
+
         for i in range(64):
             await task(self, i)
 
@@ -875,7 +876,7 @@ def actuators(loop, board, device):
         oled_id = 0
         for oled in oleds:
             oled_settings = oleds[oled]
-            if  "name" not in oled_settings:
+            if "name" not in oled_settings:
                 oled_settings["name"] = oled
             oled_obj = Oled(
                 128, 64, board, oleds[oled], port=oled_id, loop=loop

--- a/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
+++ b/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
@@ -628,7 +628,7 @@ class Oled(_SSD1306):
             # // TODO: arduino will just stop forwarding i2c write messages after a single failed message. No feedback from it yet.
             out = await self.board.i2c_write(60, cmd, i2c_port=self.i2c_port)
             if out is None:
-                await asyncio.sleep(0.01)
+                await asyncio.sleep(0.05)
             if (
                 out == False
             ):  # pico returns true/false, arduino returns always none, only catch false
@@ -720,7 +720,7 @@ class Oled(_SSD1306):
         self.temp[1] = cmd
         out = await self.board.i2c_write(60, self.temp, i2c_port=self.i2c_port)
         if out is None:
-            await asyncio.sleep(0.01)
+            await asyncio.sleep(0.05)
         if out == False:
             print("failed write oled 2")
             self.failed = True
@@ -759,7 +759,7 @@ class Oled(_SSD1306):
             buf[0] = 0x40
             out = await self.board.i2c_write(60, buf, i2c_port=self.i2c_port)
             if out is None:
-                await asyncio.sleep(0.01)
+                await asyncio.sleep(0.05)
             if out == False:
                 print("failed wrcmd")
                 self.failed = True

--- a/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
+++ b/mirte_telemetrix/scripts/ROS_telemetrix_aio_api.py
@@ -622,11 +622,13 @@ class Oled(_SSD1306):
             SetOLEDImage,
             self.set_oled_image_service,
         )
-
         for ev in self.init_awaits:
             await ev
         for cmd in self.write_commands:
+            # // TODO: arduino will just stop forwarding i2c write messages after a single failed message. No feedback from it yet.
             out = await self.board.i2c_write(60, cmd, i2c_port=self.i2c_port)
+            if(out is None):
+                await asyncio.sleep(0.1)
             if (
                 out == False
             ):  # pico returns true/false, arduino returns always none, only catch false
@@ -717,6 +719,8 @@ class Oled(_SSD1306):
         self.temp[0] = 0x80
         self.temp[1] = cmd
         out = await self.board.i2c_write(60, self.temp, i2c_port=self.i2c_port)
+        if(out is None):
+            await asyncio.sleep(0.01)
         if out == False:
             print("failed write oled 2")
             self.failed = True
@@ -736,20 +740,17 @@ class Oled(_SSD1306):
             xpos1 += 28
 
         try:
-            cmds = [
-                self.write_cmd_async(0x21),  # SET_COL_ADDR)
-                self.write_cmd_async(xpos0),
-                self.write_cmd_async(xpos1),
-                self.write_cmd_async(0x22),  # SET_PAGE_ADDR)
-                self.write_cmd_async(0),
-                self.write_cmd_async(self.pages - 1),
-                *self.write_framebuf_async(),
-            ]
-            await asyncio.gather(*cmds)
+            await self.write_cmd_async(0x21)  # SET_COL_ADDR)
+            await self.write_cmd_async(xpos0)
+            await self.write_cmd_async(xpos1)
+            await self.write_cmd_async(0x22)  # SET_PAGE_ADDR)
+            await self.write_cmd_async(0)
+            await self.write_cmd_async(self.pages - 1)
+            await self.write_framebuf_async()
         except Exception as e:
             print(e)
 
-    def write_framebuf_async(self):
+    async def write_framebuf_async(self):
         if self.failed:
             return
 
@@ -757,14 +758,13 @@ class Oled(_SSD1306):
             buf = self.buffer[i * 16 : (i + 1) * 16 + 1]
             buf[0] = 0x40
             out = await self.board.i2c_write(60, buf, i2c_port=self.i2c_port)
+            if(out is None):
+                await asyncio.sleep(0.1)
             if out == False:
                 print("failed wrcmd")
                 self.failed = True
-
-        tasks = []
         for i in range(64):
-            tasks.append(task(self, i))
-        return tasks
+            await task(self, i)
 
     def write_framebuf(self):
         for i in range(64):
@@ -837,7 +837,6 @@ def handle_get_pin_value(req):
     else:
         value = -1  # device did not report back, so return error value.
 
-    value = pin_values[pin]
     return GetPinValueResponse(value)
 
 
@@ -875,6 +874,9 @@ def actuators(loop, board, device):
         oleds = {k: v for k, v in oleds.items() if v["device"] == device}
         oled_id = 0
         for oled in oleds:
+            oled_settings = oleds[oled]
+            if  "name" not in oled_settings:
+                oled_settings["name"] = oled
             oled_obj = Oled(
                 128, 64, board, oleds[oled], port=oled_id, loop=loop
             )  # get_pin_numbers(oleds[oled]))
@@ -1050,7 +1052,7 @@ if __name__ == "__main__":
         )
         loop.run_until_complete(board.start_aio())
     else:
-        board = telemetrix_aio.TelemetrixAIO()
+        board = telemetrix_aio.TelemetrixAIO(loop=loop)
 
     # Catch signals to exit properly
     # We need to do it this way instead of usgin the try/catch


### PR DESCRIPTION
Fixes when using a Arduino
- oled: add timeout when writing to i2c to not overload the serial port
- Fix asyncio loop passing to telemetrix library to share the same loop. Without this, no serial data is ever read


Should still work with rp2040, need to test tomorrow