### PR TITLE
Support with gz harmonic

### DIFF
--- a/mirte_description/mirte_master_description/urdf/arm.xacro
+++ b/mirte_description/mirte_master_description/urdf/arm.xacro
@@ -353,7 +353,6 @@
             upper="3.14"
             effort="0.0"
             velocity="0.0" />
-        <mimic joint="gripper_joint" multiplier="1.4"/>
     </joint>
 
     <link
@@ -466,7 +465,6 @@
             upper="3.14"
             effort="0.0"
             velocity="0.0" />
-        <mimic joint="gripper_joint" multiplier="-1.4"/>
     </joint>
     <link
         name="gripper_finger_l">
@@ -579,7 +577,6 @@
             effort="2.0"
             velocity="2.0"
         />
-        <mimic joint="gripper_joint" multiplier="-1"/>
     </joint>
 
 

--- a/mirte_description/mirte_master_description/urdf/lidar.xacro
+++ b/mirte_description/mirte_master_description/urdf/lidar.xacro
@@ -85,6 +85,7 @@
   <gazebo reference="lidar_link">
         <sensor name="lidar" type="gpu_lidar">
             <always_on>true</always_on>
+            <gz_frame_id>lidar_link</gz_frame_id>
             <visualize>${visualize_sensors}</visualize>
             <update_rate>10</update_rate>
             <topic>scan</topic>

--- a/mirte_description/mirte_master_description/urdf/lidar.xacro
+++ b/mirte_description/mirte_master_description/urdf/lidar.xacro
@@ -76,12 +76,19 @@
     <xacro:property name="lidar_sensor_link" value="lidar_link" />
   </xacro:unless>
 
+  <plugin
+    filename="gz-sim-sensors-system"
+    name="gz::sim::systems::Sensors">
+    <render_engine>ogre2</render_engine>
+  </plugin>
+
   <gazebo reference="lidar_link">
-        <sensor name="lidar" type="ray">
-            <pose> 0 0 0 0 0 0 </pose>
+        <sensor name="lidar" type="gpu_lidar">
+            <always_on>true</always_on>
             <visualize>${visualize_sensors}</visualize>
             <update_rate>10</update_rate>
-            <ray>
+            <topic>scan</topic>
+            <lidar>
                 <scan>
                     <horizontal>
                         <samples>360</samples>
@@ -95,14 +102,7 @@
                     <max>12</max>
                     <resolution>0.01</resolution>
                 </range>
-            </ray>
-            <plugin name="laser_controller" filename="libgazebo_ros_ray_sensor.so">
-                <ros>
-                    <remapping>~/out:=scan</remapping>
-                </ros>
-                <output_type>sensor_msgs/LaserScan</output_type>
-                <frame_name>lidar_link</frame_name>
-            </plugin>
+            </lidar>
         </sensor>
     </gazebo>
 

--- a/mirte_description/mirte_master_description/urdf/mirte_master_base.gazebo.xacro
+++ b/mirte_description/mirte_master_description/urdf/mirte_master_base.gazebo.xacro
@@ -2,6 +2,11 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
  <xacro:if value="$(arg imu_enable)">
+  <plugin
+    filename="gz-sim-imu-system"
+    name="gz::sim::systems::Imu">
+  </plugin>
+
   <gazebo reference="imu_link">
     <gravity>true</gravity>
     <sensor name="imu_sensor" type="imu">
@@ -9,16 +14,6 @@
       <update_rate>100</update_rate>
       <visualize>true</visualize>
       <topic>__default_topic__</topic>
-      <plugin filename="libgazebo_ros_imu_sensor.so" name="imu_plugin">
-        <topicName>imu</topicName>
-        <bodyName>imu_link</bodyName>
-        <updateRateHZ>10.0</updateRateHZ>
-        <gaussianNoise>0.0</gaussianNoise>
-        <xyzOffset>0 0 0</xyzOffset>
-        <rpyOffset>0 0 0</rpyOffset>
-        <frameName>imu_link</frameName>
-        <initialOrientationAsReference>false</initialOrientationAsReference>
-      </plugin>
       <pose>0 0 0 0 0 0</pose>
     </sensor>
    </gazebo>

--- a/mirte_description/mirte_master_description/urdf/orbbec_astra_plus_pro.xacro
+++ b/mirte_description/mirte_master_description/urdf/orbbec_astra_plus_pro.xacro
@@ -117,10 +117,19 @@
      ========================================================= -->
 
      <xacro:macro name="sensor_orbbec_astra_pro_plus_gazebo">
+
+          <plugin
+               filename="gz-sim-sensors-system"
+               name="gz::sim::systems::Sensors">
+               <render_engine>ogre2</render_engine>
+          </plugin>
+
           <gazebo reference="${name}_link">
-             <sensor name="${name}" type="depth">
+             <sensor name="${name}" type="rgbd_camera">
                 <visualize>true</visualize>
                 <update_rate>60.0</update_rate>
+                <alwaysOn>true</alwaysOn>
+                <topic>rgbd_camera</topic>
                 <camera name="RS_D455">
                     <horizontal_fov>${60.0*M_PI/180.0}</horizontal_fov>
                     <image>
@@ -132,25 +141,15 @@
                         <near>0.05</near>
                         <far>10.0</far>
                     </clip>
+                    <distorsion>
+                         <k1>0.0</k1>
+                         <k2>0.0</k2>
+                         <k3>0.0</k3>
+                         <p1>0.0</p1>
+                         <p2>0.0</p2>
+                    </distorsion>
+                    <optical_frame_id>camera_link</optical_frame_id>
                 </camera>
-                <plugin name="${name}_controller" filename="libgazebo_ros_camera.so">
-                    <baseline>0.1</baseline>
-                    <alwaysOn>true</alwaysOn>
-                    <updateRate>30</updateRate>
-                    <frame_name>${name}_depth_optical_frame</frame_name>
-                    <pointCloudCutoff>0.6</pointCloudCutoff>
-                    <pointCloudCutoffMax>8.0</pointCloudCutoffMax>
-                    <distortionK1>0</distortionK1>
-                    <distortionK2>0</distortionK2>
-                    <distortionK3>0</distortionK3>
-                    <distortionT1>0</distortionT1>
-                    <distortionT2>0</distortionT2>
-                    <CxPrime>0</CxPrime>
-                    <Cx>0</Cx>
-                    <Cy>0</Cy>
-                    <focalLength>0</focalLength>
-                    <hackBaseline>0</hackBaseline>
-                </plugin>
             </sensor>
          </gazebo>
      </xacro:macro>

--- a/mirte_description/mirte_master_description/urdf/ros2_control.xacro
+++ b/mirte_description/mirte_master_description/urdf/ros2_control.xacro
@@ -18,7 +18,7 @@
    <ros2_control name="mecanumdrive" type="system">
       <hardware>
         <xacro:if value="$(arg sim)">
-          <plugin>gazebo_ros2_control/GazeboSystem</plugin>
+          <plugin>gz_ros2_control/GazeboSimSystem</plugin>
         </xacro:if>
         <xacro:unless value="$(arg sim)">
           <plugin>mirte_base_control/MirteBaseHWInterface</plugin>
@@ -46,7 +46,7 @@
 <ros2_control name="ros2_arm_control" type="system">
       <hardware>
         <xacro:if value="$(arg sim)">
-          <plugin>gazebo_ros2_control/GazeboSystem</plugin>
+          <plugin>gz_ros2_control/GazeboSimSystem</plugin>
         </xacro:if>
         <xacro:unless value="$(arg sim)">
           <plugin>mirte_master_arm_control/MirteMasterArmHWInterface</plugin>
@@ -88,7 +88,7 @@
 <ros2_control name="ros2_gripper_control" type="system">
      <hardware>
         <xacro:if value="$(arg sim)">
-          <plugin>gazebo_ros2_control/GazeboSystem</plugin>
+          <plugin>gz_ros2_control/GazeboSimSystem</plugin>
         </xacro:if>
         <xacro:unless value="$(arg sim)">
           <plugin>mirte_master_arm_control/MirteMasterArmHWInterface</plugin>
@@ -104,7 +104,6 @@
     <xacro:if value="$(arg sim)">
 
       <joint name="_Gripper_joint_r">
-        <param name="mimic">gripper_joint</param>
         <param name="multiplier">-1</param>
         <command_interface name="position"/>
         <state_interface name="position" />
@@ -112,7 +111,6 @@
       </joint>
 
       <joint name="_gripper_link_joint_l">
-        <param name="mimic">gripper_joint</param>
         <param name="multiplier">-1.4</param> 
         <command_interface name="position"/>
         <state_interface name="position" />
@@ -120,7 +118,6 @@
       </joint>
 
       <joint name="_gripper_link_joint_r">
-        <param name="mimic">gripper_joint</param>
         <param name="multiplier">1.4</param>  
         <command_interface name="position"/>
         <state_interface name="position" />
@@ -132,25 +129,31 @@
 </ros2_control>
 
 <gazebo>
-    <plugin filename="libgazebo_ros2_control.so" name="gazebo_ros2_control">
+    <plugin filename="libgz_ros2_control-system.so" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
        <parameters>$(find mirte_base_control)/config/mirte_base_control.yaml</parameters>
        <xacro:if value="$(arg arm_enable)">
           <parameters>$(find mirte_master_arm_control)/config/mirte_master_arm_control.yaml</parameters>
        </xacro:if>
     </plugin>
-    <plugin filename="libgazebo_ros_planar_move.so" name="gazebo_planar_move">
-       <robot_base_frame>base_link</robot_base_frame> 
+    <plugin
+      filename="gz-sim-mecanum-drive-system"
+      name="gz::sim::systems::MecanumDrive">
+      <front_left_joint>front_left_wheel_joint</front_left_joint>
+      <front_right_joint>front_right_wheel_joint</front_right_joint>
+      <back_left_joint>rear_left_wheel_joint</back_left_joint>
+      <back_right_joint>rear_right_wheel_joint</back_right_joint>
+      <wheel_separation>1.25</wheel_separation>
+      <wheelbase>1.511</wheelbase>
+      <wheel_radius>0.3</wheel_radius>
+      <min_acceleration>-5</min_acceleration>
+      <max_acceleration>5</max_acceleration>
+      <topic>cmd_vel</topic>
+      <odom_topic>odom</odom_topic>
+      <frame_id>odom</frame_id>
+      <child_frame_id>base_footprint</child_frame_id>
+      <odom_publisher_frequency>30</odom_publisher_frequency>
+      <tf_topic>/tf</tf_topic>
     </plugin>
-    <plugin name="libgazebo_ros_p3d" filename="libgazebo_ros_p3d.so">
-        <ros>
-            <namespace>groundtruth</namespace>
-            <remapping>odom:=odom</remapping>
-        </ros> 
-        <frame_name>world</frame_name>
-        <body_name>base_link</body_name>
-        <update_rate>200.0</update_rate>
-        <gaussian_noise>0.0</gaussian_noise>
-     </plugin>
 
 </gazebo>
 

--- a/mirte_description/mirte_master_description/urdf/ultrasonic.xacro
+++ b/mirte_description/mirte_master_description/urdf/ultrasonic.xacro
@@ -28,10 +28,18 @@
       </collision>
     </link>
 
+    <plugin
+      filename="gz-sim-sensors-system"
+      name="gz::sim::systems::Sensors">
+      <render_engine>ogre2</render_engine>
+    </plugin>
+
     <gazebo reference="${name}_sonar">
-      <sensor type="ray" name="range_sensor_${name}">
+      <sensor type="gpu_lidar" name="range_sensor_${name}">
         <visualize>${visualize_sensors}</visualize>
-          <ray>
+        <always_on>true</always_on>
+        <topic>distance/${name}</topic>
+          <lidar>
             <scan>
               <horizontal>
                 <!-- for some reason 1 does not work, we neex 2x2 -->
@@ -58,19 +66,9 @@
            <mean>0.0</mean>
            <stddev>0.01</stddev>
          </noise>
-       </ray>
+       </lidar>
        <!-- Using gazebo's update rate instead of plugin's -->
        <update_rate>30</update_rate>
-
-       <plugin name="gazebo_ros_range_controller_${name}" filename="libgazebo_ros_ray_sensor.so">
-         <ros>
-           <namespace>/mirte</namespace>
-           <remapping>~/out:=distance/${name}</remapping>
-         </ros>
-         <output_type>sensor_msgs/Range</output_type>
-         <radiation_type>ultrasound</radiation_type>
-       </plugin>
-
      </sensor>
    </gazebo>
 


### PR DESCRIPTION
Hello!

Here are the changes I made to get Mirte working in Gazebo Harmonic. The changes I had to make are to the gz drivers and plugins used.

I don't know if the Mecanum plugin has a bug or needs to be configured somehow, but it can't move linear y. I tried using the ros2_control clearpath driver, but it still didn't work in Jazzy.

I think there's a small bug in the transformation tree, which I haven't been able to find, and it's causing it to not find the wheels, but getting it working isn't a problem. You can move the robot perfectly, read information from the sensors, etc. The minimum/basic requirements would be sufficient, pending corrections and improvements.

I recommend creating a branch, for example, jazzy-devel, so as not to merge it with the rest of the humble and ros1 implementations.

Grettings ^^