### PR TITLE
add lazy publishing tmx

### DIFF
--- a/mirte_telemetrix_cpp/CMakeLists.txt
+++ b/mirte_telemetrix_cpp/CMakeLists.txt
@@ -174,7 +174,8 @@ install(TARGETS ${PROJECT_NAME}_node DESTINATION lib/${PROJECT_NAME})
 ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME}/)
 # install(DIRECTORY config DESTINATION share/${PROJECT_NAME}/)
-install(PROGRAMS scripts/default_screen.sh DESTINATION share/${PROJECT_NAME}/scripts/)
+install(PROGRAMS scripts/default_screen.sh
+        DESTINATION share/${PROJECT_NAME}/scripts/)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/mirte_telemetrix_cpp/src/modules/adxl345_module.cpp
+++ b/mirte_telemetrix_cpp/src/modules/adxl345_module.cpp
@@ -48,6 +48,10 @@ ADXL345_sensor::ADXL345_sensor(NodeData node_data, ADXL345Data imu_data,
 }
 
 void ADXL345_sensor::update() {
+  if (this->imu_pub->get_subscription_count() == 0) {
+    // No subscribers, so no need to publish
+    return;
+  }
   if (msg_mutex.try_lock()) {
     const std::lock_guard lock{msg_mutex, std::adopt_lock};
     msg.header = get_header();
@@ -56,13 +60,17 @@ void ADXL345_sensor::update() {
 }
 
 void ADXL345_sensor::data_callback(std::array<float, 3> acceleration) {
+
   const std::lock_guard<std::mutex> lock(msg_mutex);
   msg.header = get_header();
 
   msg.linear_acceleration.x = acceleration[0] * 9.81;
   msg.linear_acceleration.y = acceleration[1] * 9.81;
   msg.linear_acceleration.z = acceleration[2] * 9.81;
-
+  if (this->imu_pub->get_subscription_count() == 0) {
+    // No subscribers, so no need to publish
+    return;
+  }
   imu_pub->publish(msg);
   this->device_timer->reset();
 }

--- a/mirte_telemetrix_cpp/src/modules/hiwonder/hiwonder_servo.cpp
+++ b/mirte_telemetrix_cpp/src/modules/hiwonder/hiwonder_servo.cpp
@@ -123,6 +123,10 @@ void Hiwonder_servo::position_cb(
 }
 
 void Hiwonder_servo::update() {
+  if (this->position_pub->get_subscription_count() == 0) {
+    // No subscribers, so no need to publish
+    return;
+  }
   auto msg = mirte_msgs::build<mirte_msgs::msg::ServoPosition>()
                  .header(this->get_header())
                  .angle(this->last_angle)

--- a/mirte_telemetrix_cpp/src/modules/ina226_module.cpp
+++ b/mirte_telemetrix_cpp/src/modules/ina226_module.cpp
@@ -51,27 +51,23 @@ INA226_sensor::INA226_sensor(NodeData node_data, INA226Data ina_data,
 }
 
 // TODO: Maybe add mutex lock-out although not fully necessary
-void INA226_sensor::update() {
-  auto msg = sensor_msgs::msg::BatteryState();
-  msg.header = get_header();
-
-  msg.voltage = voltage_;
-  msg.current = current_;
-
-  msg.percentage = calc_soc(voltage_);
+void INA226_sensor::update() { // only publish at 1Hz
   if (this->battery_pub->get_subscription_count() > 0) {
+    auto msg = sensor_msgs::msg::BatteryState();
+    msg.header = get_header();
+
+    msg.voltage = voltage_;
+    msg.current = current_;
+    msg.percentage = calc_soc(voltage_);
     this->battery_pub->publish(msg);
   }
-  this->integrate_usage(current_);
-  this->check_soc(voltage_, current_);
 }
 
 void INA226_sensor::data_callback(float voltage, float current) {
   voltage_ = voltage;
   current_ = current;
-  // std::cout << "INA226 data: " << current << " " << voltage << std::endl;
-  this->update();
-  this->device_timer->reset();
+  this->integrate_usage(current_);
+  this->check_soc(voltage_, current_);
 }
 
 float INA226_sensor::calc_soc(float voltage) {

--- a/mirte_telemetrix_cpp/src/modules/ina226_module.cpp
+++ b/mirte_telemetrix_cpp/src/modules/ina226_module.cpp
@@ -59,7 +59,9 @@ void INA226_sensor::update() {
   msg.current = current_;
 
   msg.percentage = calc_soc(voltage_);
-  this->battery_pub->publish(msg);
+  if (this->battery_pub->get_subscription_count() > 0) {
+    this->battery_pub->publish(msg);
+  }
   this->integrate_usage(current_);
   this->check_soc(voltage_, current_);
 }
@@ -103,6 +105,10 @@ void INA226_sensor::integrate_usage(float current) {
 
   this->total_used_mAh += used_mAh;
   this->used_time = current_time;
+  if (this->used_pub->get_subscription_count() == 0) {
+    // No subscribers, so no need to publish
+    return;
+  }
   std_msgs::msg::Int32 msg;
   msg.data = (int32_t)this->total_used_mAh;
   this->used_pub->publish(msg);

--- a/mirte_telemetrix_cpp/src/modules/mpu9250_module.cpp
+++ b/mirte_telemetrix_cpp/src/modules/mpu9250_module.cpp
@@ -47,6 +47,10 @@ MPU9250_sensor::MPU9250_sensor(NodeData node_data, MPU9250Data imu_data,
 }
 
 void MPU9250_sensor::update() {
+  if (this->imu_pub->get_subscription_count() == 0) {
+    // No subscribers, so no need to publish
+    return;
+  }
   if (msg_mutex.try_lock()) {
     const std::lock_guard lock{msg_mutex, std::adopt_lock};
     msg.header = get_header();
@@ -73,7 +77,10 @@ void MPU9250_sensor::data_callback(std::array<float, 3> acceleration,
   msg.orientation.y = quaternion[1];
   msg.orientation.z = quaternion[2];
   msg.orientation.w = quaternion[3];
-
+  if (this->imu_pub->get_subscription_count() == 0) {
+    // No subscribers, so no need to publish
+    return;
+  }
   imu_pub->publish(msg);
   device_timer->reset();
 }

--- a/mirte_telemetrix_cpp/src/modules/veml6040_module.cpp
+++ b/mirte_telemetrix_cpp/src/modules/veml6040_module.cpp
@@ -51,7 +51,12 @@ void VEML6040_sensor::update() {
   using mirte_msgs::msg::ColorHSLStamped;
   using mirte_msgs::msg::ColorRGBAStamped;
   using mirte_msgs::msg::ColorRGBWStamped;
-
+  if (this->rgbw_pub->get_subscription_count() == 0 &&
+      this->rgba_pub->get_subscription_count() == 0 &&
+      this->hsl_pub->get_subscription_count() == 0) {
+    // No subscribers, so no need to publish
+    return;
+  }
   if (msg_mutex.try_lock_shared()) {
     const std::shared_lock lock{msg_mutex, std::adopt_lock};
     auto header = get_header();
@@ -112,17 +117,19 @@ void VEML6040_sensor::data_callback(uint16_t red, uint16_t green, uint16_t blue,
   last_rgbw.b = b;
   last_rgbw.w = w;
 
-  rgbw_pub->publish(
-      mirte_msgs::build<ColorRGBWStamped>().header(header).color(last_rgbw));
+  if (this->rgbw_pub->get_subscription_count() > 0) {
+    rgbw_pub->publish(
+        mirte_msgs::build<ColorRGBWStamped>().header(header).color(last_rgbw));
+  }
 
   last_rgba.r = r;
   last_rgba.g = g;
   last_rgba.b = b;
   last_rgba.a = 1;
-
-  rgba_pub->publish(
-      mirte_msgs::build<ColorRGBAStamped>().header(header).color(last_rgba));
-  ;
+  if (this->rgba_pub->get_subscription_count() > 0) {
+    rgba_pub->publish(
+        mirte_msgs::build<ColorRGBAStamped>().header(header).color(last_rgba));
+  }
 
   auto color_hsva = color_util::changeColorspace(color_util::ColorRGBA(
       last_rgba.r, last_rgba.g, last_rgba.b, last_rgba.a));
@@ -136,9 +143,10 @@ void VEML6040_sensor::data_callback(uint16_t red, uint16_t green, uint16_t blue,
 
   last_hsl.l = l;
   last_hsl.s = (l >= 1.0 or l <= 0.0) ? 0.0 : ((v - l) / std::min(l, 1 - l));
-
-  hsl_pub->publish(
-      mirte_msgs::build<ColorHSLStamped>().header(header).color(last_hsl));
+  if (this->hsl_pub->get_subscription_count() > 0) {
+    hsl_pub->publish(
+        mirte_msgs::build<ColorHSLStamped>().header(header).color(last_hsl));
+  }
 }
 
 void VEML6040_sensor::get_rgbw_service_callback(

--- a/mirte_telemetrix_cpp/src/parsers/modules/ina226_data.cpp
+++ b/mirte_telemetrix_cpp/src/parsers/modules/ina226_data.cpp
@@ -42,6 +42,7 @@ INA226Data::INA226Data(std::shared_ptr<Parser> parser,
                          "enable)");
 #endif
   }
+  this->duration = DeviceDuration(1000.0 / 1.0); // 1Hz default
 }
 
 bool INA226Data::check() {

--- a/mirte_telemetrix_cpp/src/sensors/encoder_monitor.cpp
+++ b/mirte_telemetrix_cpp/src/sensors/encoder_monitor.cpp
@@ -33,10 +33,13 @@ void EncoderMonitor::data_callback(int16_t value) {
 }
 
 void EncoderMonitor::update() {
+  if (this->encoder_pub->get_subscription_count() == 0) {
+    // No subscribers, so no need to publish
+    return;
+  }
   auto msg = mirte_msgs::build<mirte_msgs::msg::Encoder>()
                  .header(get_header()) // Build the message
                  .value(value);
-
   encoder_pub->publish(msg);
 }
 

--- a/mirte_telemetrix_cpp/src/sensors/intensity_monitor.cpp
+++ b/mirte_telemetrix_cpp/src/sensors/intensity_monitor.cpp
@@ -40,6 +40,10 @@ void DigitalIntensityMonitor::data_callback(uint16_t value) {
 }
 
 void DigitalIntensityMonitor::update() {
+  if (this->intensity_pub->get_subscription_count() == 0) {
+    // No subscribers, so no need to publish
+    return;
+  }
   auto msg = mirte_msgs::build<mirte_msgs::msg::IntensityDigital>()
                  .header(get_header()) // Build the message
                  .value(value);
@@ -97,6 +101,10 @@ void AnalogIntensityMonitor::data_callback(uint16_t value) {
 }
 
 void AnalogIntensityMonitor::update() {
+  if (this->intensity_pub->get_subscription_count() == 0) {
+    // No subscribers, so no need to publish
+    return;
+  }
   auto msg = mirte_msgs::build<mirte_msgs::msg::Intensity>()
                  .header(get_header()) // Build the message
                  .value(value);

--- a/mirte_telemetrix_cpp/src/sensors/keypad_monitor.cpp
+++ b/mirte_telemetrix_cpp/src/sensors/keypad_monitor.cpp
@@ -109,14 +109,18 @@ void KeypadMonitor::update() {
   }
 
   // Publish the last debounced key
-  this->keypad_pub->publish(msg_builder.key(key_string(debounced_key)));
+  if (this->keypad_pub->get_subscription_count() > 0) {
+    this->keypad_pub->publish(msg_builder.key(key_string(debounced_key)));
+  }
 
   // # check if we need to send a pressed message
   if (this->last_debounced_key != NONE &&
       this->last_debounced_key != debounced_key) // TODO: check this
   {
-    this->keypad_pressed_pub->publish(
-        msg_builder.key(key_string(this->last_debounced_key)));
+    if (this->keypad_pub->get_subscription_count() > 0) {
+      this->keypad_pressed_pub->publish(
+          msg_builder.key(key_string(this->last_debounced_key)));
+    }
   }
 
   this->last_debounced_key = debounced_key;

--- a/mirte_telemetrix_cpp/src/sensors/sonar_monitor.cpp
+++ b/mirte_telemetrix_cpp/src/sensors/sonar_monitor.cpp
@@ -88,10 +88,11 @@ void SonarMonitor::update() {
           .min_range(this->min_range)
           .max_range(this->max_range)
           .range(this->distance);
-
-  this->sonar_pub->publish(msg);
   const std::lock_guard<std::mutex> lock(msg_mutex);
   this->range = msg;
+  if (this->sonar_pub->get_subscription_count() > 0) {
+    this->sonar_pub->publish(msg);
+  }
 }
 
 void SonarMonitor::service_callback(


### PR DESCRIPTION
Encoding small messages is slow and wastes time, especially when there is no subscriber. This PR will skip publishing (and encoding) when there is no subscriber.