### PR TITLE
Changed mecanum plugin to mirte base controller

### DIFF
--- a/mirte_control/mirte_master_arm_control/bringup/launch/mirte_master_arm_control.launch.py
+++ b/mirte_control/mirte_master_arm_control/bringup/launch/mirte_master_arm_control.launch.py
@@ -108,7 +108,7 @@ def generate_launch_description():
     robot_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["mirte_master_arm_controller", "mirte_master_gripper_controller"],
+        arguments=["mirte_master_base_control", "mirte_master_arm_controller", "mirte_master_gripper_controller"],
     )
 
     nodes = [

--- a/mirte_control/mirte_master_arm_control/bringup/launch/mirte_master_arm_control.launch.py
+++ b/mirte_control/mirte_master_arm_control/bringup/launch/mirte_master_arm_control.launch.py
@@ -111,7 +111,7 @@ def generate_launch_description():
         arguments=[
             "mirte_master_base_control",
             "mirte_master_arm_controller",
-            "mirte_master_gripper_controller"
+            "mirte_master_gripper_controller",
         ],
     )
 

--- a/mirte_control/mirte_master_arm_control/bringup/launch/mirte_master_arm_control.launch.py
+++ b/mirte_control/mirte_master_arm_control/bringup/launch/mirte_master_arm_control.launch.py
@@ -108,7 +108,11 @@ def generate_launch_description():
     robot_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["mirte_master_base_control", "mirte_master_arm_controller", "mirte_master_gripper_controller"],
+        arguments=[
+            "mirte_master_base_control",
+            "mirte_master_arm_controller",
+            "mirte_master_gripper_controller"
+        ],
     )
 
     nodes = [

--- a/mirte_control/mirte_master_base_control/bringup/config/mirte_base_control.yaml
+++ b/mirte_control/mirte_master_base_control/bringup/config/mirte_base_control.yaml
@@ -9,45 +9,36 @@
       type: pid_controller/PidController
 
     mirte_base_controller:
-      type: clearpath_mecanum_drive_controller/MecanumDriveController
+      type: mecanum_drive_controller/MecanumDriveController
 
 /**/mirte_base_controller:
   ros__parameters:
-    # hardware_parameters:
-    # ticks: 1320
-    use_stamped_vel: false  # Stamped will be the future default
     reference_timeout: 0.25
     command_timeout: 0.25
-    command_joint_names: ["pid_wheels_controller/front_left_wheel_joint", "pid_wheels_controller/rear_left_wheel_joint", "pid_wheels_controller/rear_right_wheel_joint", "pid_wheels_controller/front_right_wheel_joint"]
-    state_joint_names: ["front_left_wheel_joint", "rear_left_wheel_joint", "rear_right_wheel_joint", "front_right_wheel_joint"]
+
+    front_left_wheel_command_joint_name: front_left_wheel_joint
+    rear_left_wheel_command_joint_name: rear_left_wheel_joint
+    rear_right_wheel_command_joint_name: rear_right_wheel_joint
+    front_right_wheel_command_joint_name: front_right_wheel_joint
+
+    front_left_wheel_state_joint_name: front_left_wheel_joint
+    rear_left_wheel_state_joint_name: rear_left_wheel_joint
+    rear_right_wheel_state_joint_name: rear_right_wheel_joint
+    front_right_wheel_state_joint_name: front_right_wheel_joint
+
     interface_name: velocity
 
     kinematics:
       base_frame_offset: { x: 0.0, y: 0.0, theta: 0.0 }
-
       wheels_radius: 0.051
+      sum_of_robot_center_projection_on_X_Y_axis: 0.225
 
-        # Wheels kinematic parameters [m]: (from odometry.hpp)
-        # lx and ly represent the distance from the robot's center to the wheels
-        #  projected on the x and y axis with origin at robots center respectively,
-        #  sum_of_robot_center_projection_on_X_Y_axis_ = lx+ly
-
-      sum_of_robot_center_projection_on_X_Y_axis: 0.225 # 0.18/2+0.27/2 = 0.225
-          # wheel_separation_x: 0.18
-          # wheel_separation_y: 0.27
-
-
-    # These need to be evaluated since this controller does not support frame_prefixes
-    base_frame_id: "$(var frame_prefix '')base_link"
-    odom_frame_id: "$(var frame_prefix '')odom"
-
+    base_frame_id: base_link
+    odom_frame_id: odom
     enable_odom_tf: true
 
     twist_covariance_diagonal: [0.0, 7.0, 14.0, 21.0, 28.0, 35.0]
-
     pose_covariance_diagonal: [0.0, 7.0, 14.0, 21.0, 28.0, 35.0]
-
-
 
 /**/pid_wheels_controller:
   ros__parameters:

--- a/mirte_control/mirte_master_base_control/bringup/config/mirte_base_control_no_pid.yaml
+++ b/mirte_control/mirte_master_base_control/bringup/config/mirte_base_control_no_pid.yaml
@@ -5,64 +5,34 @@
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
-    # pid_wheels_controller:
-    #   type: pid_controller/PidController
-
     mirte_base_controller:
-      type: clearpath_mecanum_drive_controller/MecanumDriveController
+      type: mecanum_drive_controller/MecanumDriveController
 
 /**/mirte_base_controller:
   ros__parameters:
-    # hardware_parameters:
-    # ticks: 1320
-    use_stamped_vel: false  # Stamped will be the future default
     reference_timeout: 0.25
     command_timeout: 0.25
-    command_joint_names: ["front_left_wheel_joint", "rear_left_wheel_joint", "rear_right_wheel_joint", "front_right_wheel_joint"]
-    state_joint_names: ["front_left_wheel_joint", "rear_left_wheel_joint", "rear_right_wheel_joint", "front_right_wheel_joint"]
+
+    front_left_wheel_command_joint_name: front_left_wheel_joint
+    rear_left_wheel_command_joint_name: rear_left_wheel_joint
+    rear_right_wheel_command_joint_name: rear_right_wheel_joint
+    front_right_wheel_command_joint_name: front_right_wheel_joint
+
+    front_left_wheel_state_joint_name: front_left_wheel_joint
+    rear_left_wheel_state_joint_name: rear_left_wheel_joint
+    rear_right_wheel_state_joint_name: rear_right_wheel_joint
+    front_right_wheel_state_joint_name: front_right_wheel_joint
+
     interface_name: velocity
 
     kinematics:
       base_frame_offset: { x: 0.0, y: 0.0, theta: 0.0 }
-
       wheels_radius: 0.051
+      sum_of_robot_center_projection_on_X_Y_axis: 0.225
 
-        # Wheels kinematic parameters [m]: (from odometry.hpp)
-        # lx and ly represent the distance from the robot's center to the wheels
-        #  projected on the x and y axis with origin at robots center respectively,
-        #  sum_of_robot_center_projection_on_X_Y_axis_ = lx+ly
-
-      sum_of_robot_center_projection_on_X_Y_axis: 0.225 # 0.18/2+0.27/2 = 0.225
-          # wheel_separation_x: 0.18
-          # wheel_separation_y: 0.27
-
-
-    # These need to be evaluated since this controller does not support frame_prefixes
-    base_frame_id: "$(var frame_prefix '')base_link"
-    odom_frame_id: "$(var frame_prefix '')odom"
-
+    base_frame_id: base_link
+    odom_frame_id: odom
     enable_odom_tf: true
 
     twist_covariance_diagonal: [0.0, 7.0, 14.0, 21.0, 28.0, 35.0]
-
     pose_covariance_diagonal: [0.0, 7.0, 14.0, 21.0, 28.0, 35.0]
-
-
-
-# /**/pid_wheels_controller:
-#   ros__parameters:
-#     command_interface: velocity
-
-#     reference_and_state_interfaces: ["velocity"]
-
-#     # reference_and_state_dof_names:
-#     dof_names:
-#       - front_left_wheel_joint
-#       - rear_left_wheel_joint
-#       - rear_right_wheel_joint
-#       - front_right_wheel_joint
-#     gains:
-#       front_left_wheel_joint: {p: 1.0, i: 0.0, d: 0.0, i_clamp_max: 5.0, i_clamp_min: -5.0}
-#       rear_left_wheel_joint: {p: 1.0, i: 0.0, d: 0.0, i_clamp_max: 5.0, i_clamp_min: -5.0}
-#       rear_right_wheel_joint: {p: 1.0, i: 0.0, d: 0.0, i_clamp_max: 5.0, i_clamp_min: -5.0}
-#       front_right_wheel_joint: {p: 1.0, i: 0.0, d: 0.0, i_clamp_max: 5.0, i_clamp_min: -5.0}

--- a/mirte_control/mirte_master_base_control/package.xml
+++ b/mirte_control/mirte_master_base_control/package.xml
@@ -72,7 +72,7 @@
   <exec_depend>ros2launch</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>ros2_controllers</exec_depend>
-  <exec_depend>diff_drive_controller</exec_depend>
+  <exec_depend>mecanum_drive_controller</exec_depend>
   <exec_depend>effort_controllers</exec_depend>
   <exec_depend>twist_stamper</exec_depend>
 

--- a/mirte_description/mirte_master_description/config/mirte_base_control.yaml
+++ b/mirte_description/mirte_master_description/config/mirte_base_control.yaml
@@ -50,7 +50,6 @@ mirte_gripper_controller:
 
 mirte_base_controller:
   ros__parameters:
-    use_stamped_vel: false
     reference_timeout: 0.25
     command_timeout: 0.25
 

--- a/mirte_description/mirte_master_description/config/mirte_base_control.yaml
+++ b/mirte_description/mirte_master_description/config/mirte_base_control.yaml
@@ -9,7 +9,7 @@
       type: pid_controller/PidController
 
     mirte_base_controller:
-      type: clearpath_mecanum_drive_controller/MecanumDriveController
+      type: mecanum_drive_controller/MecanumDriveController
 
     mirte_arm_controller:
       type: joint_trajectory_controller/JointTrajectoryController
@@ -50,39 +50,30 @@ mirte_gripper_controller:
 
 mirte_base_controller:
   ros__parameters:
-    # hardware_parameters:
-    # ticks: 1320
-    use_stamped_vel: false # This will become the default in the future
+    use_stamped_vel: false
     reference_timeout: 0.25
     command_timeout: 0.25
-    command_joint_names: ["wheel_left_front_joint", "wheel_left_rear_joint", "wheel_right_rear_joint", "wheel_right_front_joint"]
-    state_joint_names: ["wheel_left_front_joint", "wheel_left_rear_joint", "wheel_right_rear_joint", "wheel_right_front_joint"]
+
+    front_left_wheel_command_joint_name: wheel_left_front_joint
+    rear_left_wheel_command_joint_name: wheel_left_rear_joint
+    rear_right_wheel_command_joint_name: wheel_right_rear_joint
+    front_right_wheel_command_joint_name: wheel_right_front_joint
+
+    front_left_wheel_state_joint_name: wheel_left_front_joint
+    rear_left_wheel_state_joint_name: wheel_left_rear_joint
+    rear_right_wheel_state_joint_name: wheel_right_rear_joint
+    front_right_wheel_state_joint_name: wheel_right_front_joint
+
     interface_name: velocity
 
     kinematics:
       base_frame_offset: { x: 0.0, y: 0.0, theta: 0.0 }
-
       wheels_radius: 0.051
+      sum_of_robot_center_projection_on_X_Y_axis: 0.225
 
-        # Wheels kinematic parameters [m]: (from odometry.hpp)
-        # lx and ly represent the distance from the robot's center to the wheels
-        #  projected on the x and y axis with origin at robots center respectively,
-        #  sum_of_robot_center_projection_on_X_Y_axis_ = lx+ly
-
-      sum_of_robot_center_projection_on_X_Y_axis: 0.225 # 0.18/2+0.27/2 = 0.225
-          # wheel_separation_x: 0.18
-          # wheel_separation_y: 0.27
-
-
-    # These need to be evaluated since this controller does not support frame_prefixes
-    base_frame_id: "$(var frame_prefix '')base_link"
-    odom_frame_id: "$(var frame_prefix '')odom"
-
+    base_frame_id: "base_link"
+    odom_frame_id: "odom"
     enable_odom_tf: true
-
-#    twist_covariance_diagonal: [0.0, 7.0, 14.0, 21.0, 28.0, 35.0]
-
-#    pose_covariance_diagonal: [0.0, 7.0, 14.0, 21.0, 28.0, 35.0]
 
 
 

--- a/mirte_description/mirte_master_description/urdf/ros2_control.xacro
+++ b/mirte_description/mirte_master_description/urdf/ros2_control.xacro
@@ -130,31 +130,11 @@
 
 <gazebo>
     <plugin filename="libgz_ros2_control-system.so" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
-       <parameters>$(find mirte_base_control)/config/mirte_base_control.yaml</parameters>
+       <parameters>$(find mirte_base_control)/config/mirte_base_control_no_pid.yaml</parameters>
        <xacro:if value="$(arg arm_enable)">
           <parameters>$(find mirte_master_arm_control)/config/mirte_master_arm_control.yaml</parameters>
        </xacro:if>
     </plugin>
-    <plugin
-      filename="gz-sim-mecanum-drive-system"
-      name="gz::sim::systems::MecanumDrive">
-      <front_left_joint>front_left_wheel_joint</front_left_joint>
-      <front_right_joint>front_right_wheel_joint</front_right_joint>
-      <back_left_joint>rear_left_wheel_joint</back_left_joint>
-      <back_right_joint>rear_right_wheel_joint</back_right_joint>
-      <wheel_separation>1.25</wheel_separation>
-      <wheelbase>1.511</wheelbase>
-      <wheel_radius>0.3</wheel_radius>
-      <min_acceleration>-5</min_acceleration>
-      <max_acceleration>5</max_acceleration>
-      <topic>cmd_vel</topic>
-      <odom_topic>odom</odom_topic>
-      <frame_id>odom</frame_id>
-      <child_frame_id>base_footprint</child_frame_id>
-      <odom_publisher_frequency>30</odom_publisher_frequency>
-      <tf_topic>/tf</tf_topic>
-    </plugin>
-
 </gazebo>
 
 </robot>

--- a/sources.repos
+++ b/sources.repos
@@ -19,7 +19,3 @@ repositories:
     type: git
     url: https://github.com/ArendJan/usb_cam.git # for lazy publishing
     version: main
-  clearpath_mecanum_drive_controller:
-    type: git
-    url: https://github.com/Juancams/clearpath_mecanum_drive_controller.git
-    version: jazzy

--- a/sources.repos
+++ b/sources.repos
@@ -19,3 +19,7 @@ repositories:
     type: git
     url: https://github.com/ArendJan/usb_cam.git # for lazy publishing
     version: main
+  clearpath_mecanum_drive_controller:
+    type: git
+    url: https://github.com/Juancams/clearpath_mecanum_drive_controller.git
+    version: jazzy


### PR DESCRIPTION
I've made some small changes to get the clearpath mecanum driver working in the jazzy version. I'll do a PR, and I expect it to be packaged at some point. For now, I've put it in a .repos file you had.

Now, instead of using the mecanum plugin, it's using the ros2 control driver.