### PR TITLE
sonar max range 0.3m

### DIFF
--- a/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/sensors/sonar_monitor.hpp
+++ b/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/sensors/sonar_monitor.hpp
@@ -15,8 +15,8 @@ class SonarMonitor : public Mirte_Sensor {
 public:
   /// @brief The minimum range in meters. 0.02 Meters for the HC-SR04.
   const double min_range = 0.02;
-  /// @brief The maximum range in meters. 4.50 Meters for the HC-SR04.
-  const double max_range = 4.5;
+  /// @brief The maximum range in meters. 4.00 Meters for the HC-SR04.
+  const double max_range = 0.3;
 
   SonarMonitor(NodeData node_data, SonarData sonar_data);
 


### PR DESCRIPTION
Change sonar max range to 0.3m
The sonar measurements get really bad with distance. I think we should limit it to 0.3m as the sonar are used to not bump into small obstacles close by, not for mapping/localization.
In addition, nav2 relies on the `max_range` field to filter out sonar readings.

PS: the sensor max range is 4m, not 4.5m

<img width="1393" height="610" alt="image" src="https://github.com/user-attachments/assets/1a315874-4386-460d-8178-877d9cd38c01" />

