### PR TITLE
Reduce `/io/power/power_watcher` pub frequency

### DIFF
--- a/mirte_telemetrix_cpp/src/parsers/modules/ina226_data.cpp
+++ b/mirte_telemetrix_cpp/src/parsers/modules/ina226_data.cpp
@@ -1,11 +1,13 @@
 #include <mirte_telemetrix_cpp/parsers/modules/ina226_data.hpp>
 
+using namespace std::chrono_literals;
+
 INA226Data::INA226Data(std::shared_ptr<Parser> parser,
                        std::shared_ptr<Mirte_Board> board, std::string name,
                        std::map<std::string, rclcpp::ParameterValue> parameters,
                        std::set<std::string> &unused_keys)
     : I2CModuleData(parser, board, name, parameters, unused_keys,
-                    get_module_type()) {
+                    get_module_type(), std::chrono::duration_cast<DeviceDuration>(50s)) {
   auto logger =
       parser->logger.get_child(get_device_class()).get_child(this->name);
 


### PR DESCRIPTION
`ros2 topic echo /io/power/power_watcher sensor_msgs/msg/BatteryState --field percentage >/tmp/batteryState` takes around 20% CPU usage

<img width="3698" height="636" alt="Image" src="https://github.com/user-attachments/assets/1906d6e6-b9c8-4a33-9ee9-327ed6612ccb" />

I believe this can be improved by decreasing the rate of the battery publisher. Battery consumption is not that dynamic, IMO it doesn't need to be published at 45hz. I recommend setting it very low, like 1hz.

```
ros2 topic hz /io/power/power_watcher
average rate: 44.579
	min: 0.002s max: 0.040s std dev: 0.00733s window: 45
average rate: 44.249
	min: 0.000s max: 0.055s std dev: 0.00858s window: 90
average rate: 44.652
	min: 0.000s max: 0.055s std dev: 0.00802s window: 136
average rate: 44.764
	min: 0.000s max: 0.055s std dev: 0.00767s window: 182
average rate: 44.906
	min: 0.000s max: 0.055s std dev: 0.00762s window: 228
average rate: 44.881
	min: 0.000s max: 0.055s std dev: 0.00743s window: 273
```

I set the `INA226Data` to initialize `I2CModuleData` with duration = `std::chrono::duration_cast<DeviceDuration>(50s)`
Now the frequency is around `4.7hz` which is weird, it should be around `1hz`. I tried changing the value of device duration but it doesn't matter the value I put, it always publishes at `4.7hz` which is equivalent to passing `std::chrono::duration_cast<DeviceDuration>(10s)`

```
ros2 topic hz /io/power/power_watcher
WARNING: topic [/io/power/power_watcher] does not appear to be published yet
average rate: 4.504
	min: 0.139s max: 0.309s std dev: 0.05716s window: 6
average rate: 4.670
	min: 0.139s max: 0.309s std dev: 0.04315s window: 11
average rate: 4.715
	min: 0.139s max: 0.309s std dev: 0.03607s window: 16
average rate: 4.661
	min: 0.139s max: 0.309s std dev: 0.03680s window: 21
average rate: 4.700
	min: 0.139s max: 0.309s std dev: 0.03329s window: 26
average rate: 4.657
	min: 0.139s max: 0.309s std dev: 0.03710s window: 31
```

But anyway, with this frequency, the cpu consumption of `ros2 topic echo /io/power/power_watchersensor_msgs/msg/BatteryState --field percentage >/tmp/batteryState`  drops to 2%

<img width="3280" height="1118" alt="Image" src="https://github.com/user-attachments/assets/87e327e4-71db-4882-ba7c-0f1f309a9fd0" />