### PR TITLE
telemetrix fix oled crashing, add retries

### DIFF
--- a/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/modules/ssd1306_module.hpp
+++ b/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/modules/ssd1306_module.hpp
@@ -12,6 +12,7 @@
 #include <mirte_msgs/srv/set_oled_image.hpp>
 #include <mirte_msgs/srv/set_oled_image_legacy.hpp>
 #include <mirte_msgs/srv/set_oled_text.hpp>
+#include <std_srvs/srv/trigger.hpp>
 
 namespace fs = std::filesystem;
 
@@ -35,7 +36,9 @@ public:
   virtual void device_timer_callback() override;
 
 private:
-  bool enabled = true;
+//   bool enabled = true;
+//   int ok_count = 3;
+  int retries = 3;
   bool default_screen = true;
   std::optional<std::string> last_text;
 
@@ -54,6 +57,8 @@ private:
   rclcpp::Service<mirte_msgs::srv::SetOLEDFile>::SharedPtr
       set_oled_file_service;
 
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr
+      start_default_screen_service;
   bool prewrite(bool is_default = false);
 
   void set_oled_callback_legacy(

--- a/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/modules/ssd1306_module.hpp
+++ b/mirte_telemetrix_cpp/include/mirte_telemetrix_cpp/modules/ssd1306_module.hpp
@@ -36,8 +36,8 @@ public:
   virtual void device_timer_callback() override;
 
 private:
-//   bool enabled = true;
-//   int ok_count = 3;
+  //   bool enabled = true;
+  //   int ok_count = 3;
   int retries = 3;
   bool default_screen = true;
   std::optional<std::string> last_text;

--- a/mirte_telemetrix_cpp/src/modules/ssd1306_module.cpp
+++ b/mirte_telemetrix_cpp/src/modules/ssd1306_module.cpp
@@ -79,11 +79,14 @@ SSD1306_module::SSD1306_module(NodeData node_data, SSD1306Data oled_data,
           std::bind(&SSD1306_module::set_oled_file_callback, this, _1, _2),
           rmw_qos_profile_services_default, this->callback_group);
 
-  this->start_default_screen_service = nh->create_service<std_srvs::srv::Trigger>("oled/"+data.name + "/start_default_screen", [&](    const std_srvs::srv::Trigger::Request::ConstSharedPtr req,
-    std_srvs::srv::Trigger::Response::SharedPtr res) {
-    this->default_screen = true;
-    this->retries = 5;
-  });
+  this->start_default_screen_service =
+      nh->create_service<std_srvs::srv::Trigger>(
+          "oled/" + data.name + "/start_default_screen",
+          [&](const std_srvs::srv::Trigger::Request::ConstSharedPtr req,
+              std_srvs::srv::Trigger::Response::SharedPtr res) {
+            this->default_screen = true;
+            this->retries = 5;
+          });
   modules->add_mod(this->ssd1306);
   // Write an initial text to the screen, and instantly kill the timer if it has
   // failed.
@@ -97,7 +100,7 @@ SSD1306_module::SSD1306_module(NodeData node_data, SSD1306Data oled_data,
                  this->data.name.c_str());
     this->retries--;
   } else {
-    this->retries=3;
+    this->retries = 3;
   }
 }
 
@@ -107,7 +110,8 @@ bool SSD1306_module::prewrite(bool is_default) {
   }
 
   if (this->retries < 0) {
-    // RCLCPP_ERROR(logger, "Writing to OLED Module %s failed", data.name.c_str());
+    // RCLCPP_ERROR(logger, "Writing to OLED Module %s failed",
+    // data.name.c_str());
     return false;
   }
   return true;
@@ -124,7 +128,7 @@ bool SSD1306_module::set_text(std::string text) {
   }
   last_text = escaped_text;
   auto succes = ssd1306->send_text(escaped_text);
-  if (! succes) {
+  if (!succes) {
     this->retries--;
   } else {
     this->retries = 5;
@@ -149,7 +153,7 @@ bool SSD1306_module::set_image(uint8_t width, uint8_t height,
   }
 
   auto succes = ssd1306->send_image(width, height, img_buffer);
-  if (! succes) {
+  if (!succes) {
     this->retries--;
   } else {
     this->retries = 5;
@@ -296,6 +300,8 @@ void SSD1306_module::device_timer_callback() {
     auto text = exec(data.default_screen_script);
 
     auto escaped_text = boost::algorithm::replace_all_copy(text, "\\n", "\n");
+    escaped_text = escaped_text.substr(
+        0, std::min((size_t)ssd1306->character_limit, escaped_text.length()));
     if (escaped_text == last_text) {
       return;
     }
@@ -305,12 +311,10 @@ void SSD1306_module::device_timer_callback() {
     succes = set_image_from_path(data.default_screen_script);
   }
 
-  if (! succes) {
+  if (!succes) {
     this->retries--;
     // enabled = false;
-    RCLCPP_ERROR(
-        logger,
-        "Default screen update failed.");
+    RCLCPP_ERROR(logger, "Default screen update failed.");
   } else {
     this->retries = 5;
   }

--- a/mirte_telemetrix_cpp/src/modules/ssd1306_module.cpp
+++ b/mirte_telemetrix_cpp/src/modules/ssd1306_module.cpp
@@ -79,17 +79,25 @@ SSD1306_module::SSD1306_module(NodeData node_data, SSD1306Data oled_data,
           std::bind(&SSD1306_module::set_oled_file_callback, this, _1, _2),
           rmw_qos_profile_services_default, this->callback_group);
 
+  this->start_default_screen_service = nh->create_service<std_srvs::srv::Trigger>("oled/"+data.name + "/start_default_screen", [&](    const std_srvs::srv::Trigger::Request::ConstSharedPtr req,
+    std_srvs::srv::Trigger::Response::SharedPtr res) {
+    this->default_screen = true;
+    this->retries = 5;
+  });
   modules->add_mod(this->ssd1306);
   // Write an initial text to the screen, and instantly kill the timer if it has
   // failed.
   /* NOTE: This needs to use the raw send_text, because otherwise the
    * default_screen_timer will be canceled. */
+
   if (!this->ssd1306->send_text("Booting...", 500ms)) {
     RCLCPP_ERROR(this->logger,
                  "Writing to OLED module '%s' failed, shutting down default "
                  "screen timer.",
                  this->data.name.c_str());
-    this->enabled = false;
+    this->retries--;
+  } else {
+    this->retries=3;
   }
 }
 
@@ -98,8 +106,8 @@ bool SSD1306_module::prewrite(bool is_default) {
     this->default_screen = false;
   }
 
-  if (!enabled) {
-    RCLCPP_ERROR(logger, "Writing to OLED Module %s failed", data.name.c_str());
+  if (this->retries < 0) {
+    // RCLCPP_ERROR(logger, "Writing to OLED Module %s failed", data.name.c_str());
     return false;
   }
   return true;
@@ -116,8 +124,10 @@ bool SSD1306_module::set_text(std::string text) {
   }
   last_text = escaped_text;
   auto succes = ssd1306->send_text(escaped_text);
-  if (not succes) {
-    enabled = false;
+  if (! succes) {
+    this->retries--;
+  } else {
+    this->retries = 5;
   }
 
   return succes;
@@ -139,8 +149,10 @@ bool SSD1306_module::set_image(uint8_t width, uint8_t height,
   }
 
   auto succes = ssd1306->send_image(width, height, img_buffer);
-  if (not succes) {
-    enabled = false;
+  if (! succes) {
+    this->retries--;
+  } else {
+    this->retries = 5;
   }
 
   return succes;
@@ -267,7 +279,7 @@ void SSD1306_module::set_oled_file_callback(
 }
 
 void SSD1306_module::device_timer_callback() {
-  if (!enabled) {
+  if (!this->retries < 0) {
     return;
   }
   if (!default_screen) {
@@ -293,10 +305,13 @@ void SSD1306_module::device_timer_callback() {
     succes = set_image_from_path(data.default_screen_script);
   }
 
-  if (not succes) {
-    enabled = false;
+  if (! succes) {
+    this->retries--;
+    // enabled = false;
     RCLCPP_ERROR(
         logger,
-        "Default screen update failed. Disabling screen and update timer.");
+        "Default screen update failed.");
+  } else {
+    this->retries = 5;
   }
 }

--- a/mirte_telemetrix_cpp/src/parsers/modules/ssd1306_data.cpp
+++ b/mirte_telemetrix_cpp/src/parsers/modules/ssd1306_data.cpp
@@ -16,7 +16,7 @@ SSD1306Data::SSD1306Data(
                                          rclcpp::ParameterValue("ssd1306")),
                     insert_default_param(unused_keys, "type"),
                     get_device_class(),
-                    std::chrono::duration_cast<DeviceDuration>(10s)) {
+                    std::chrono::duration_cast<DeviceDuration>(1s)) {
   // Set default for address
   if ((!parameters.count("addr")) && this->addr == 0xFF) {
     this->addr = 0x3C;

--- a/mirte_telemetrix_cpp/src/parsers/modules/ssd1306_data.cpp
+++ b/mirte_telemetrix_cpp/src/parsers/modules/ssd1306_data.cpp
@@ -16,7 +16,7 @@ SSD1306Data::SSD1306Data(
                                          rclcpp::ParameterValue("ssd1306")),
                     insert_default_param(unused_keys, "type"),
                     get_device_class(),
-                    std::chrono::duration_cast<DeviceDuration>(1s)) {
+                    std::chrono::duration_cast<DeviceDuration>(10s)) {
   // Set default for address
   if ((!parameters.count("addr")) && this->addr == 0xFF) {
     this->addr = 0x3C;


### PR DESCRIPTION
Improves oled stability by using retries before disabling oled.

Adds service to enable default screen after other write to it, this also reset the retry count if the oled failed during operation.