### PR TITLE
msgs: deal with CMake CMP0094

### DIFF
--- a/mirte_msgs/CMakeLists.txt
+++ b/mirte_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 project(mirte_msgs)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "clang")


### PR DESCRIPTION
Bump CMake minimum version to `3.15`, as that's where `CMP0094` was introduced.

CMake versions lower than `3.15` have trouble locating Python in environments where a Python installed in a non-default location should be used (such as Conda, Pixi, etc).

This should fix #103.
