### PR TITLE
`mirte_control`: only add `-g` for GCC and Clang

### DIFF
--- a/mirte_control/mirte_master_arm_control/CMakeLists.txt
+++ b/mirte_control/mirte_master_arm_control/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.9)
 project(mirte_master_arm_control)
-add_compile_options(-g)
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
+  add_compile_options(-g)
+endif()
 
 set(CMAKE_CXX_STANDARD 20)
 find_package(ament_cmake REQUIRED)

--- a/mirte_control/mirte_master_base_control/CMakeLists.txt
+++ b/mirte_control/mirte_master_base_control/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.9)
 project(mirte_base_control)
-add_compile_options(-g)
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
+  add_compile_options(-g)
+endif()
 
 set(CMAKE_CXX_STANDARD 20)
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
MSVC doesn't support it.

Technically there might be more compilers that support `-g`, but I haven't checked.
